### PR TITLE
Replace TagLibSharp with Meziantou.Framework.MediaTags

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Helpers/MusicLibraryTestContext.cs
+++ b/Meziantou.MusicApp.Server.Tests/Helpers/MusicLibraryTestContext.cs
@@ -1,4 +1,5 @@
 using Meziantou.Framework;
+using Meziantou.Framework.MediaTags;
 
 namespace Meziantou.MusicApp.Server.Tests.Helpers;
 
@@ -46,82 +47,41 @@ internal sealed class MusicLibraryTestContext(FullPath root)
         fullPath.CreateParentDirectory();
         File.WriteAllBytes(fullPath, mp3Data);
 
-        // Use TagLibSharp to add ID3 tags
-        using var tagFile = TagLib.File.Create(fullPath);
-        
-        if (title != null)
+        var tags = new MediaTagInfo
         {
-            tagFile.Tag.Title = title;
+            Title = title,
+            Artist = artist,
+            AlbumArtist = albumArtist,
+            Album = album,
+            Genre = genre,
+            Year = year,
+            TrackNumber = track.HasValue ? (int)track.Value : null,
+        };
+
+        if (!string.IsNullOrWhiteSpace(lyrics))
+        {
+            tags.Lyrics = lyrics;
         }
 
-        if (album != null)
+        if (!string.IsNullOrWhiteSpace(isrc))
         {
-            tagFile.Tag.Album = album;
+            tags.Isrc = isrc;
         }
 
-        if (genre != null)
+        if (replayGainTrackGain.HasValue || replayGainTrackPeak.HasValue)
         {
-            tagFile.Tag.Genres = [genre];
-        }
-
-        if (year.HasValue)
-        {
-            tagFile.Tag.Year = (uint)year.Value;
-        }
-
-        if (track.HasValue)
-        {
-            tagFile.Tag.Track = track.Value;
-        }
-
-        if (artist != null)
-        {
-            tagFile.Tag.Performers = [artist];
-        }
-
-        if (albumArtist != null)
-        {
-            tagFile.Tag.AlbumArtists = [albumArtist];
-        }
-
-        if (lyrics != null)
-        {
-            tagFile.Tag.Lyrics = lyrics;
-        }
-
-        // Add ISRC if provided
-        if (isrc != null)
-        {
-            if (tagFile.GetTag(TagLib.TagTypes.Id3v2, true) is TagLib.Id3v2.Tag id3v2Tag)
+            tags.ReplayGain = new ReplayGainInfo
             {
-                var tsrcFrame = TagLib.Id3v2.TextInformationFrame.Get(id3v2Tag, "TSRC", true);
-                tsrcFrame.Text = [isrc];
-            }
+                TrackGain = replayGainTrackGain,
+                TrackPeak = replayGainTrackPeak,
+            };
         }
 
-        // Add ReplayGain if provided
-        if (replayGainTrackGain.HasValue && replayGainTrackPeak.HasValue)
+        var writeResult = MediaFile.WriteTags(fullPath, tags);
+        if (!writeResult.IsSuccess)
         {
-            var trackGainStr = $"{replayGainTrackGain.Value:F2} dB";
-            var trackPeakStr = $"{replayGainTrackPeak.Value:F6}";
-
-            if (tagFile.GetTag(TagLib.TagTypes.Id3v2, true) is TagLib.Id3v2.Tag id3v2Tag)
-            {
-                var trackGainFrame = new TagLib.Id3v2.UserTextInformationFrame("REPLAYGAIN_TRACK_GAIN")
-                {
-                    Text = [trackGainStr]
-                };
-                id3v2Tag.AddFrame(trackGainFrame);
-
-                var trackPeakFrame = new TagLib.Id3v2.UserTextInformationFrame("REPLAYGAIN_TRACK_PEAK")
-                {
-                    Text = [trackPeakStr]
-                };
-                id3v2Tag.AddFrame(trackPeakFrame);
-            }
+            throw new InvalidOperationException($"Failed to write media tags: {writeResult.ErrorMessage}");
         }
-
-        tagFile.Save();
     }
 
     public async Task CreateLrcFile(string relativePath, string content)

--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using Meziantou.Framework;
+using Meziantou.Framework.MediaTags;
 using Meziantou.MusicApp.Server.Models;
 using Meziantou.MusicApp.Server.Services;
 using Meziantou.MusicApp.Server.Tests.Helpers;
@@ -540,13 +541,16 @@ public partial class MusicLibraryServiceTests
         Assert.Equal("Original Title", songs[0].Title);
 
         // Modify the file and ensure it's fully written before scanning
-        using (var tagFile = TagLib.File.Create(mp3FilePath))
-        {
-            tagFile.Tag.Title = "Modified Title";
-            tagFile.Tag.Performers = ["Modified Artist"];
-            tagFile.Tag.Album = "Modified Album";
-            tagFile.Save();
-        } // Dispose to ensure file is closed
+        var readResult = MediaFile.ReadTags(mp3FilePath);
+        Assert.True(readResult.IsSuccess, $"Failed to read media tags: {readResult.ErrorMessage}");
+
+        var tags = readResult.Value;
+        tags.Title = "Modified Title";
+        tags.Artist = "Modified Artist";
+        tags.Album = "Modified Album";
+
+        var writeResult = MediaFile.WriteTags(mp3FilePath, tags);
+        Assert.True(writeResult.IsSuccess, $"Failed to write media tags: {writeResult.ErrorMessage}");
 
         // Explicitly update the file timestamp to ensure modification is detected
         var timestampBefore = File.GetLastWriteTimeUtc(mp3FilePath);

--- a/Meziantou.MusicApp.Server.Tests/Unit/ReplayGainServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/ReplayGainServiceTests.cs
@@ -2,6 +2,7 @@ using Meziantou.MusicApp.Server.Models;
 using Meziantou.MusicApp.Server.Services;
 using Meziantou.MusicApp.Server.Tests.Helpers;
 using Meziantou.Framework;
+using Meziantou.Framework.MediaTags;
 
 namespace Meziantou.MusicApp.Server.Tests.Unit;
 
@@ -245,64 +246,34 @@ public class ReplayGainServiceTests
 
     private static (double? TrackGain, double? TrackPeak) ReadReplayGainTagsFromFile(FullPath path)
     {
-        using var file = TagLib.File.Create(path);
-
-        double? trackGain = null;
-        double? trackPeak = null;
-
-        // Read from ID3v2 tags (MP3)
-        if (file.GetTag(TagLib.TagTypes.Id3v2) is TagLib.Id3v2.Tag id3v2Tag)
+        var readResult = MediaFile.ReadTags(path);
+        if (!readResult.IsSuccess)
         {
-            foreach (var frame in id3v2Tag.GetFrames<TagLib.Id3v2.UserTextInformationFrame>())
-            {
-                var value = frame.Text.FirstOrDefault();
-                if (string.IsNullOrEmpty(value))
-                    continue;
-
-                if (frame.Description?.Equals("REPLAYGAIN_TRACK_GAIN", StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    var cleanValue = value.Replace(" dB", "", StringComparison.OrdinalIgnoreCase).Trim();
-                    if (double.TryParse(cleanValue, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var gain))
-                    {
-                        trackGain = gain;
-                    }
-                }
-                else if (frame.Description?.Equals("REPLAYGAIN_TRACK_PEAK", StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var peak))
-                    {
-                        trackPeak = peak;
-                    }
-                }
-            }
+            return (null, null);
         }
 
-        return (trackGain, trackPeak);
+        return (readResult.Value.ReplayGain?.TrackGain, readResult.Value.ReplayGain?.TrackPeak);
     }
 
     private static void WriteReplayGainTagsToFile(FullPath path, double trackGain, double trackPeak)
     {
-        using var file = TagLib.File.Create(path);
-
-        var trackGainStr = $"{trackGain:F2} dB";
-        var trackPeakStr = $"{trackPeak:F6}";
-
-        // Write to ID3v2 tags (MP3)
-        if (file.GetTag(TagLib.TagTypes.Id3v2, true) is TagLib.Id3v2.Tag id3v2Tag)
+        var readResult = MediaFile.ReadTags(path);
+        if (!readResult.IsSuccess)
         {
-            var trackGainFrame = new TagLib.Id3v2.UserTextInformationFrame("REPLAYGAIN_TRACK_GAIN")
-            {
-                Text = [trackGainStr]
-            };
-            id3v2Tag.AddFrame(trackGainFrame);
-
-            var trackPeakFrame = new TagLib.Id3v2.UserTextInformationFrame("REPLAYGAIN_TRACK_PEAK")
-            {
-                Text = [trackPeakStr]
-            };
-            id3v2Tag.AddFrame(trackPeakFrame);
+            throw new InvalidOperationException($"Failed to read media tags: {readResult.ErrorMessage}");
         }
 
-        file.Save();
+        var tags = readResult.Value;
+        tags.ReplayGain = new ReplayGainInfo
+        {
+            TrackGain = trackGain,
+            TrackPeak = trackPeak,
+        };
+
+        var writeResult = MediaFile.WriteTags(path, tags);
+        if (!writeResult.IsSuccess)
+        {
+            throw new InvalidOperationException($"Failed to write media tags: {writeResult.ErrorMessage}");
+        }
     }
 }

--- a/Meziantou.MusicApp.Server/Meziantou.MusicApp.Server.csproj
+++ b/Meziantou.MusicApp.Server/Meziantou.MusicApp.Server.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Meziantou.Framework.FullPath" Version="1.1.17" />
     <PackageReference Include="Meziantou.Framework.StronglyTypedId" Version="2.3.11" />
-    <PackageReference Include="TagLibSharp" Version="2.3.0" />
+    <PackageReference Include="Meziantou.Framework.MediaTags" Version="1.1.0" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
+++ b/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Security.Cryptography;
 using Meziantou.Framework;
+using Meziantou.Framework.MediaTags;
 using Meziantou.MusicApp.Server.Telemetry;
 
 namespace Meziantou.MusicApp.Server.Models;
@@ -627,15 +628,15 @@ public sealed class MusicCatalog
             if (coverArt.IsMetadata)
             {
                 // Read from embedded metadata
-                using var tagFile = TagLib.File.Create(coverArt.FilePath);
-                var pictures = tagFile.Tag.Pictures;
-                if (pictures.Length > 0)
+                var readResult = MediaFile.ReadTags(coverArt.FilePath);
+                if (readResult.IsSuccess && readResult.Value.Pictures.Count > 0)
                 {
+                    var pictureData = readResult.Value.Pictures[0].Data;
                     activity?.SetTag("music.coverart.result", "from_metadata");
-                    activity?.SetTag("music.coverart.size_bytes", pictures[0].Data.Data.Length);
+                    activity?.SetTag("music.coverart.size_bytes", pictureData.Length);
                     return new CoverArtData
                     {
-                        Data = pictures[0].Data.Data,
+                        Data = pictureData,
                         LastModified = lastModified,
                     };
                 }
@@ -677,8 +678,13 @@ public sealed class MusicCatalog
             if (song.Lyrics.IsMetadata)
             {
                 // Read from embedded metadata
-                using var tagFile = TagLib.File.Create(song.Lyrics.FilePath);
-                var lyrics = tagFile.Tag.Lyrics;
+                string? lyrics = null;
+                var readResult = MediaFile.ReadTags(song.Lyrics.FilePath);
+                if (readResult.IsSuccess)
+                {
+                    lyrics = readResult.Value.Lyrics;
+                }
+
                 activity?.SetTag("music.lyrics.result", "from_metadata");
                 if (lyrics is not null)
                 {
@@ -792,11 +798,10 @@ public sealed class MusicCatalog
             if (coverArt.IsMetadata)
             {
                 // Extract from embedded metadata
-                using var tagFile = TagLib.File.Create(coverArt.FilePath);
-                var pictures = tagFile.Tag.Pictures;
-                if (pictures.Length > 0)
+                var readResult = MediaFile.ReadTags(coverArt.FilePath);
+                if (readResult.IsSuccess && readResult.Value.Pictures.Count > 0)
                 {
-                    imageData = pictures[0].Data.Data;
+                    imageData = readResult.Value.Pictures[0].Data;
                 }
             }
             else

--- a/Meziantou.MusicApp.Server/README.md
+++ b/Meziantou.MusicApp.Server/README.md
@@ -6,7 +6,7 @@ This project is a music streaming server that supports both Subsonic and Jellyfi
 
 - Dual API Support: Subsonic REST API (v1.16.1) and Jellyfin API (v10.9)
 - Automatic M3U/M3U8 playlist detection
-- ID3 tag reading using TagLibSharp
+- ID3 tag reading using Meziantou.Framework.MediaTags
 - Lyrics support from file metadata
 - Cover art extraction from files or folders
 - Simple token-based authentication

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -5,6 +5,7 @@ using System.Xml.Linq;
 using Meziantou.MusicApp.Server.Models;
 using Meziantou.MusicApp.Server.Telemetry;
 using Meziantou.Framework;
+using Meziantou.Framework.MediaTags;
 using Microsoft.Extensions.Options;
 
 namespace Meziantou.MusicApp.Server.Services;
@@ -401,22 +402,25 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
 
             try
             {
-                using var file = TagLib.File.Create(context.Path);
-                newSong.Title = file.Tag.Title ?? context.Path.NameWithoutExtension;
-                newSong.AlbumName = file.Tag.Album;
-                newSong.Artist = file.Tag.FirstPerformer;
-                newSong.AlbumArtist = file.Tag.FirstAlbumArtist ?? file.Tag.FirstPerformer ?? string.Empty;
-                newSong.Genre = file.Tag.FirstGenre ?? string.Empty;
-                newSong.Year = (int)file.Tag.Year;
-                newSong.Track = (int)file.Tag.Track;
-                newSong.Duration = file.Properties.Duration;
-                newSong.BitRate = file.Properties.AudioBitrate;
-                newSong.Lyrics = file.Tag.Lyrics;
+                var readResult = MediaFile.ReadTags(context.Path);
+                if (!readResult.IsSuccess)
+                {
+                    throw new InvalidOperationException(readResult.ErrorMessage);
+                }
 
-                // Read ISRC from different tag formats
-                ReadIsrcTag(file, newSong);
+                var tags = readResult.Value;
+                newSong.Title = tags.Title ?? context.Path.NameWithoutExtension;
+                newSong.AlbumName = tags.Album;
+                newSong.Artist = tags.Artist;
+                newSong.AlbumArtist = tags.AlbumArtist ?? tags.Artist ?? string.Empty;
+                newSong.Genre = tags.Genre ?? string.Empty;
+                newSong.Year = tags.Year ?? 0;
+                newSong.Track = tags.TrackNumber ?? 0;
+                newSong.Lyrics = tags.Lyrics;
 
-                if (file.Tag.Pictures.Length > 0)
+                newSong.Isrc = tags.Isrc;
+
+                if (tags.Pictures.Count > 0)
                 {
                     newSong.HasEmbeddedCover = true;
                 }
@@ -435,7 +439,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                 }
 
                 // Read ReplayGain tags from file
-                ReadReplayGainTags(file, newSong);
+                ReadReplayGainTags(tags, newSong);
             }
             catch (Exception ex)
             {
@@ -465,139 +469,14 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         }
     }
 
-    private static void ReadReplayGainTags(TagLib.File file, SerializableSong song)
+    private static void ReadReplayGainTags(MediaTagInfo tags, SerializableSong song)
     {
-        // Try to read ReplayGain from different tag formats
-        // ID3v2 tags (MP3)
-        if (file.GetTag(TagLib.TagTypes.Id3v2) is TagLib.Id3v2.Tag id3v2Tag)
+        if (tags.ReplayGain is { } replayGain)
         {
-            foreach (var frame in id3v2Tag.GetFrames<TagLib.Id3v2.TextInformationFrame>())
-            {
-                var value = frame.Text.FirstOrDefault();
-                if (string.IsNullOrEmpty(value))
-                    continue;
-
-                // TXXX frames for ReplayGain
-                if (frame is TagLib.Id3v2.UserTextInformationFrame userFrame)
-                {
-                    ParseReplayGainTag(userFrame.Description, userFrame.Text.FirstOrDefault(), song);
-                }
-            }
-
-            // Also check TXXX frames directly
-            foreach (var frame in id3v2Tag.GetFrames<TagLib.Id3v2.UserTextInformationFrame>())
-            {
-                ParseReplayGainTag(frame.Description, frame.Text.FirstOrDefault(), song);
-            }
-        }
-
-        // Xiph Comment (Vorbis/FLAC/Opus)
-        if (file.GetTag(TagLib.TagTypes.Xiph) is TagLib.Ogg.XiphComment xiphTag)
-        {
-            var trackGain = xiphTag.GetFirstField("REPLAYGAIN_TRACK_GAIN");
-            var trackPeak = xiphTag.GetFirstField("REPLAYGAIN_TRACK_PEAK");
-            var albumGain = xiphTag.GetFirstField("REPLAYGAIN_ALBUM_GAIN");
-            var albumPeak = xiphTag.GetFirstField("REPLAYGAIN_ALBUM_PEAK");
-
-            ParseReplayGainTag("REPLAYGAIN_TRACK_GAIN", trackGain, song);
-            ParseReplayGainTag("REPLAYGAIN_TRACK_PEAK", trackPeak, song);
-            ParseReplayGainTag("REPLAYGAIN_ALBUM_GAIN", albumGain, song);
-            ParseReplayGainTag("REPLAYGAIN_ALBUM_PEAK", albumPeak, song);
-        }
-
-        // Apple tags (M4A/AAC)
-        if (file.GetTag(TagLib.TagTypes.Apple) is TagLib.Mpeg4.AppleTag appleTag)
-        {
-            // Apple stores ReplayGain in custom atoms
-            // ----:com.apple.iTunes:replaygain_track_gain
-            var trackGainItem = appleTag.GetDashBox("com.apple.iTunes", "replaygain_track_gain");
-            var trackPeakItem = appleTag.GetDashBox("com.apple.iTunes", "replaygain_track_peak");
-            var albumGainItem = appleTag.GetDashBox("com.apple.iTunes", "replaygain_album_gain");
-            var albumPeakItem = appleTag.GetDashBox("com.apple.iTunes", "replaygain_album_peak");
-
-            ParseReplayGainTag("REPLAYGAIN_TRACK_GAIN", trackGainItem, song);
-            ParseReplayGainTag("REPLAYGAIN_TRACK_PEAK", trackPeakItem, song);
-            ParseReplayGainTag("REPLAYGAIN_ALBUM_GAIN", albumGainItem, song);
-            ParseReplayGainTag("REPLAYGAIN_ALBUM_PEAK", albumPeakItem, song);
-        }
-    }
-
-    private static void ReadIsrcTag(TagLib.File file, SerializableSong song)
-    {
-        // Try to read ISRC from different tag formats
-        // ID3v2 tags (MP3) - TSRC frame
-        if (file.GetTag(TagLib.TagTypes.Id3v2) is TagLib.Id3v2.Tag id3v2Tag)
-        {
-            // Look for TSRC frame (official ISRC frame in ID3v2)
-            foreach (var frame in id3v2Tag.GetFrames<TagLib.Id3v2.TextInformationFrame>())
-            {
-                if (frame.FrameId.ToString() == "TSRC")
-                {
-                    var isrc = frame.Text.FirstOrDefault();
-                    if (!string.IsNullOrWhiteSpace(isrc))
-                    {
-                        song.Isrc = isrc;
-                        return;
-                    }
-                }
-            }
-        }
-
-        // Xiph Comment (Vorbis/FLAC/Opus) - ISRC field
-        if (file.GetTag(TagLib.TagTypes.Xiph) is TagLib.Ogg.XiphComment xiphTag)
-        {
-            var isrc = xiphTag.GetFirstField("ISRC");
-            if (!string.IsNullOrWhiteSpace(isrc))
-            {
-                song.Isrc = isrc;
-                return;
-            }
-        }
-
-        // Apple tags (M4A/AAC)
-        if (file.GetTag(TagLib.TagTypes.Apple) is TagLib.Mpeg4.AppleTag appleTag)
-        {
-            // Try to get ISRC from standard atom
-            var isrcItem = appleTag.GetDashBox("com.apple.iTunes", "ISRC");
-            if (!string.IsNullOrWhiteSpace(isrcItem))
-            {
-                song.Isrc = isrcItem;
-                return;
-            }
-        }
-    }
-
-    private static void ParseReplayGainTag(string? tagName, string? value, SerializableSong song)
-    {
-        if (string.IsNullOrWhiteSpace(tagName) || string.IsNullOrWhiteSpace(value))
-            return;
-
-        // Normalize tag name for comparison
-        var normalizedName = tagName.ToUpperInvariant().Replace(" ", "_", StringComparison.Ordinal);
-
-        // Remove " dB" suffix if present and parse the value
-        var cleanValue = value.Replace(" dB", "", StringComparison.OrdinalIgnoreCase)
-                              .Replace("dB", "", StringComparison.OrdinalIgnoreCase)
-                              .Trim();
-
-        if (!double.TryParse(cleanValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var numValue))
-            return;
-
-        if (normalizedName.Contains("REPLAYGAIN_TRACK_GAIN", StringComparison.Ordinal))
-        {
-            song.ReplayGainTrackGain = numValue;
-        }
-        else if (normalizedName.Contains("REPLAYGAIN_TRACK_PEAK", StringComparison.Ordinal))
-        {
-            song.ReplayGainTrackPeak = numValue;
-        }
-        else if (normalizedName.Contains("REPLAYGAIN_ALBUM_GAIN", StringComparison.Ordinal))
-        {
-            song.ReplayGainAlbumGain = numValue;
-        }
-        else if (normalizedName.Contains("REPLAYGAIN_ALBUM_PEAK", StringComparison.Ordinal))
-        {
-            song.ReplayGainAlbumPeak = numValue;
+            song.ReplayGainTrackGain = replayGain.TrackGain;
+            song.ReplayGainTrackPeak = replayGain.TrackPeak;
+            song.ReplayGainAlbumGain = replayGain.AlbumGain;
+            song.ReplayGainAlbumPeak = replayGain.AlbumPeak;
         }
     }
 
@@ -644,79 +523,37 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             activity?.SetTag("music.replaygain.track_peak", trackPeak.Value);
         }
 
-        FullPath tempFilePath = FullPath.FromPath(filePath.Value + ".tmp");
-
         try
         {
-            // Copy the original file to the temporary file
-            File.Copy(filePath, tempFilePath, overwrite: true);
-
-            // Get the mimetype from the original file's extension
-            var mimeType = GetMimeTypeFromExtension(filePath.Value);
-
-            using (var file = TagLib.File.Create(tempFilePath, mimeType, TagLib.ReadStyle.Average))
+            var readResult = MediaFile.ReadTags(filePath);
+            if (!readResult.IsSuccess)
             {
-                // Format values according to ReplayGain spec
-                var trackGainStr = string.Create(CultureInfo.InvariantCulture, $"{trackGain:F2} dB");
-                var trackPeakStr = trackPeak.HasValue ? string.Create(CultureInfo.InvariantCulture, $"{trackPeak.Value:F6}") : null;
-
-                // Write to ID3v2 tags (MP3)
-                if (file.GetTag(TagLib.TagTypes.Id3v2, create: true) is TagLib.Id3v2.Tag id3v2Tag)
-                {
-                    // Remove existing ReplayGain frames first
-                    RemoveId3v2ReplayGainFrames(id3v2Tag);
-
-                    // Add track gain
-                    var trackGainFrame = new TagLib.Id3v2.UserTextInformationFrame("REPLAYGAIN_TRACK_GAIN")
-                    {
-                        Text = [trackGainStr]
-                    };
-                    id3v2Tag.AddFrame(trackGainFrame);
-
-                    // Add track peak
-                    if (trackPeakStr is not null)
-                    {
-                        var trackPeakFrame = new TagLib.Id3v2.UserTextInformationFrame("REPLAYGAIN_TRACK_PEAK")
-                        {
-                            Text = [trackPeakStr]
-                        };
-                        id3v2Tag.AddFrame(trackPeakFrame);
-                    }
-                }
-
-                // Write to Xiph Comment (Vorbis/FLAC/Opus)
-                if (file.GetTag(TagLib.TagTypes.Xiph, create: true) is TagLib.Ogg.XiphComment xiphTag)
-                {
-                    xiphTag.SetField("REPLAYGAIN_TRACK_GAIN", trackGainStr);
-                    if (trackPeakStr is not null)
-                    {
-                        xiphTag.SetField("REPLAYGAIN_TRACK_PEAK", trackPeakStr);
-                    }
-                }
-
-                // Write to Apple tags (M4A/AAC)
-                if (file.GetTag(TagLib.TagTypes.Apple, create: true) is TagLib.Mpeg4.AppleTag appleTag)
-                {
-                    appleTag.SetDashBox("com.apple.iTunes", "replaygain_track_gain", trackGainStr);
-                    if (trackPeakStr is not null)
-                    {
-                        appleTag.SetDashBox("com.apple.iTunes", "replaygain_track_peak", trackPeakStr);
-                    }
-                }
-
-                file.Save();
+                logger.LogWarning("Failed to read tags to write ReplayGain for {Path}: {Error}", filePath, readResult.ErrorMessage);
+                return;
             }
 
-            // Replace the original file with the temporary file
-            File.Move(tempFilePath, filePath, overwrite: true);
+            var tags = readResult.Value;
+            tags.ReplayGain = (tags.ReplayGain ?? default) with
+            {
+                TrackGain = trackGain,
+                TrackPeak = trackPeak,
+            };
+
+            var writeResult = MediaFile.WriteTags(filePath, tags);
+            if (!writeResult.IsSuccess)
+            {
+                logger.LogWarning("Failed to write ReplayGain tags to {Path}: {Error}", filePath, writeResult.ErrorMessage);
+                return;
+            }
 
             logger.LogDebug("Wrote ReplayGain tags to {Path}", filePath);
 
             // Verify tags were written correctly
-            using (var file = TagLib.File.Create(filePath))
+            var verificationResult = MediaFile.ReadTags(filePath);
+            if (verificationResult.IsSuccess)
             {
                 var song = new SerializableSong { RelativePath = "" };
-                ReadReplayGainTags(file, song);
+                ReadReplayGainTags(verificationResult.Value, song);
 
                 if (!song.ReplayGainTrackGain.HasValue || Math.Abs(song.ReplayGainTrackGain.Value - trackGain) > 0.01)
                 {
@@ -731,54 +568,14 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                     }
                 }
             }
+            else
+            {
+                logger.LogError("Failed to verify ReplayGain tags for {Path}: {Error}", filePath, verificationResult.ErrorMessage);
+            }
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to write ReplayGain tags to {Path}", filePath);
-        }
-        finally
-        {
-            // Clean up temporary file if it still exists
-            if (File.Exists(tempFilePath))
-            {
-                try
-                {
-                    File.Delete(tempFilePath);
-                }
-                catch
-                {
-                    // Ignore cleanup errors
-                }
-            }
-        }
-    }
-
-    private static string? GetMimeTypeFromExtension(string filePath)
-    {
-        var extension = Path.GetExtension(filePath).ToLowerInvariant();
-        return extension switch
-        {
-            ".mp3" => "taglib/mp3",
-            ".flac" => "taglib/flac",
-            ".ogg" => "taglib/ogg",
-            ".opus" => "taglib/opus",
-            ".m4a" => "taglib/m4a",
-            ".aac" => "taglib/aac",
-            ".wma" => "taglib/wma",
-            ".wav" => "taglib/wav",
-            _ => null,
-        };
-    }
-
-    private static void RemoveId3v2ReplayGainFrames(TagLib.Id3v2.Tag id3v2Tag)
-    {
-        var framesToRemove = id3v2Tag.GetFrames<TagLib.Id3v2.UserTextInformationFrame>()
-            .Where(f => f.Description?.Contains("REPLAYGAIN", StringComparison.OrdinalIgnoreCase) == true)
-            .ToList();
-
-        foreach (var frame in framesToRemove)
-        {
-            id3v2Tag.RemoveFrame(frame);
         }
     }
 

--- a/Meziantou.MusicApp.StaticSiteGenerator/Meziantou.MusicApp.StaticSiteGenerator.csproj
+++ b/Meziantou.MusicApp.StaticSiteGenerator/Meziantou.MusicApp.StaticSiteGenerator.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Meziantou.Framework.ProcessWrapper" Version="1.0.0" />
-    <PackageReference Include="TagLibSharp" Version="2.3.0" />
+    <PackageReference Include="Meziantou.Framework.MediaTags" Version="1.1.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>
 

--- a/Meziantou.MusicApp.StaticSiteGenerator/Program.cs
+++ b/Meziantou.MusicApp.StaticSiteGenerator/Program.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using Meziantou.Framework;
+using Meziantou.Framework.MediaTags;
 
 namespace Meziantou.MusicApp.StaticSiteGenerator;
 
@@ -274,7 +275,7 @@ internal sealed class Program
             await ConvertToOpus(songPath, outputPath, opusBitrate);
         }
 
-        // Extract metadata using TagLib
+        // Extract metadata
         string title;
         string? artists = null;
         string? album = null;
@@ -284,18 +285,23 @@ internal sealed class Program
 
         try
         {
-            using var file = TagLib.File.Create(songPath);
-            var tag = file.Tag;
+            var readResult = MediaFile.ReadTags(songPath);
+            if (!readResult.IsSuccess)
+            {
+                throw new InvalidOperationException(readResult.ErrorMessage);
+            }
+
+            var tag = readResult.Value;
 
             title = !string.IsNullOrWhiteSpace(tag.Title)
                 ? tag.Title
                 : Path.GetFileNameWithoutExtension(songPath);
 
-            artists = tag.JoinedPerformers;
+            artists = tag.Artist;
             album = tag.Album;
-            track = tag.Track > 0 ? (int)tag.Track : null;
-            year = tag.Year > 0 ? (int)tag.Year : null;
-            genre = tag.JoinedGenres;
+            track = tag.TrackNumber > 0 ? tag.TrackNumber : null;
+            year = tag.Year > 0 ? tag.Year : null;
+            genre = tag.Genre;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This change replaces TagLibSharp with Meziantou.Framework.MediaTags so metadata handling is centralized on one library and we can rely on its native field support (including lyrics and ISRC).

## What changed
- Replaced `TagLibSharp` package references with `Meziantou.Framework.MediaTags` (updated to `1.1.0`) in:
  - `Meziantou.MusicApp.Server`
  - `Meziantou.MusicApp.StaticSiteGenerator`
- Migrated metadata read/write code from `TagLib` APIs to `MediaFile`/`MediaTagInfo` in server and static site generator code paths.
- Updated ReplayGain handling to use `MediaTagInfo.ReplayGain` directly.
- Removed custom fallback parsing for lyrics and ISRC custom fields and now use `tags.Lyrics` and `tags.Isrc` from the library.
- Updated test helpers and affected tests to write/read metadata via MediaTags APIs.
- Updated server README dependency mention accordingly.

## Notes for reviewers
- The migration intentionally removes format-specific manual tag parsing that is now provided by MediaTags.
- Behavior-related checks covered by existing tests (including ReplayGain, lyrics, and ISRC flows) were run with `dotnet test`.

## Validation
- `dotnet test` (121 tests passed)