### PR TITLE
Add Safari/macOS AirPlay button to WebPlayer

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/README.md
+++ b/Meziantou.MusicApp.WebPlayer/README.md
@@ -12,6 +12,7 @@ The features
 - Auto-sync: Background playlist refresh and automatic track downloading
 - Search: Quick search across tracks, artists, and albums
 - Playback Controls: Play, pause, seek, shuffle, repeat modes
+- AirPlay: Stream audio to AirPlay devices on Safari/macOS
 - Media Session API: System-level media controls and notifications
 - Dark Theme: Easy on the eyes
 - Scrobbler Support

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
@@ -233,6 +233,12 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
 
       <div className="player-right">
         <div className="player-secondary-actions">
+          {playerState.isAirPlayAvailable && (
+            <AirPlayButton
+              active={playerState.isAirPlayActive}
+              onClick={() => playerActions.showAirPlayPicker()}
+            />
+          )}
           <QueueButton
             queueLength={playerState.queue.length}
             onClick={onQueueClick}
@@ -394,6 +400,21 @@ function QueueButton({ queueLength, onClick }: { queueLength: number; onClick: (
           {queueLength > 99 ? '99+' : queueLength}
         </span>
       )}
+    </button>
+  );
+}
+
+function AirPlayButton({ active, onClick }: { active: boolean; onClick: () => void }) {
+  return (
+    <button
+      className={`icon-button airplay-btn ${active ? 'active' : ''}`}
+      title="AirPlay"
+      aria-label="Open AirPlay device picker"
+      onClick={onClick}
+    >
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M6 21h12l-6-6-6 6zm15-18H3a2 2 0 0 0-2 2v11h2V5h18v11h2V5a2 2 0 0 0-2-2z" />
+      </svg>
     </button>
   );
 }

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
@@ -15,6 +15,9 @@ export interface AudioPlayerState {
   queue: QueueItem[];
   lookaheadQueue: QueueItem[];
   isLoading: boolean;
+  isAirPlaySupported: boolean;
+  isAirPlayAvailable: boolean;
+  isAirPlayActive: boolean;
 }
 
 export interface AudioPlayerActions {
@@ -45,6 +48,7 @@ export interface AudioPlayerActions {
   getCurrentPlaylistId: () => string | null;
   getCurrentIndex: () => number;
   loadRecentlyPlayed: () => Promise<void>;
+  showAirPlayPicker: () => void;
 }
 
 export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
@@ -61,6 +65,9 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
     queue: audioPlayer.getQueue(),
     lookaheadQueue: audioPlayer.getLookaheadQueue(),
     isLoading: false,
+    isAirPlaySupported: audioPlayer.isAirPlaySupported(),
+    isAirPlayAvailable: audioPlayer.isAirPlayAvailable(),
+    isAirPlayActive: audioPlayer.isAirPlayActive(),
   });
 
   const timeUpdateThrottleRef = useRef<number>(0);
@@ -131,6 +138,15 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
       {
         event: 'error',
         handler: () => setState(prev => ({ ...prev, isLoading: false })),
+      },
+      {
+        event: 'airplayavailabilitychange',
+        handler: () => setState(prev => ({
+          ...prev,
+          isAirPlaySupported: audioPlayer.isAirPlaySupported(),
+          isAirPlayAvailable: audioPlayer.isAirPlayAvailable(),
+          isAirPlayActive: audioPlayer.isAirPlayActive(),
+        })),
       },
     ];
 
@@ -218,6 +234,7 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
     getCurrentPlaylistId: () => audioPlayer.getCurrentPlaylistId(),
     getCurrentIndex: () => audioPlayer.getCurrentIndex(),
     loadRecentlyPlayed: () => audioPlayer.loadRecentlyPlayed(),
+    showAirPlayPicker: () => audioPlayer.showAirPlayPicker(),
   }), []);
 
   return [state, actions];

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
@@ -224,4 +224,49 @@ describe('AudioPlayerService Queue Logic', () => {
       // Should be playing Track 2, not a random track
       expect(player.getCurrentTrack()?.id).toBe('2');
     });
-  });});
+  });
+
+  describe('AirPlay', () => {
+    it('should expose AirPlay availability changes', () => {
+      const audio = (player as any).audio as HTMLAudioElement;
+
+      const availableEvent = new Event('webkitplaybacktargetavailabilitychanged') as WebKitPlaybackTargetAvailabilityEvent;
+      availableEvent.availability = 'available';
+      audio.dispatchEvent(availableEvent);
+
+      expect(player.isAirPlaySupported()).toBe(true);
+      expect(player.isAirPlayAvailable()).toBe(true);
+      expect(player.isAirPlayActive()).toBe(false);
+
+      const unavailableEvent = new Event('webkitplaybacktargetavailabilitychanged') as WebKitPlaybackTargetAvailabilityEvent;
+      unavailableEvent.availability = 'not-available';
+      audio.dispatchEvent(unavailableEvent);
+
+      expect(player.isAirPlayAvailable()).toBe(false);
+    });
+
+    it('should update AirPlay active state when target changes', () => {
+      const audio = (player as any).audio as HTMLAudioElement;
+
+      audio.webkitCurrentPlaybackTargetIsWireless = true;
+      audio.dispatchEvent(new Event('webkitcurrentplaybacktargetiswirelesschanged'));
+      expect(player.isAirPlayActive()).toBe(true);
+
+      audio.webkitCurrentPlaybackTargetIsWireless = false;
+      audio.dispatchEvent(new Event('webkitcurrentplaybacktargetiswirelesschanged'));
+      expect(player.isAirPlayActive()).toBe(false);
+    });
+
+    it('should open the AirPlay picker when requested', () => {
+      const audio = (player as any).audio as HTMLAudioElement;
+      const pickerSpy = vi.spyOn(
+        audio as HTMLAudioElement & { webkitShowPlaybackTargetPicker: () => void },
+        'webkitShowPlaybackTargetPicker',
+      );
+
+      player.showAirPlayPicker();
+
+      expect(pickerSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -14,7 +14,8 @@ export type PlayerEventType =
   | 'durationchange'
   | 'loadstart'
   | 'canplay'
-  | 'queuechange';
+  | 'queuechange'
+  | 'airplayavailabilitychange';
 
 export interface PlayerEventDetail {
   currentTime?: number;
@@ -23,6 +24,9 @@ export interface PlayerEventDetail {
   error?: string;
   track?: TrackInfo;
   quality?: StreamingQuality;
+  airPlaySupported?: boolean;
+  airPlayAvailable?: boolean;
+  airPlayActive?: boolean;
 }
 
 type PlayerEventCallback = (detail: PlayerEventDetail) => void;
@@ -75,8 +79,14 @@ export class AudioPlayerService {
   private recentlyPlayedIds: Set<string> = new Set();
   private static readonly RECENTLY_PLAYED_MAX_COUNT = 300;
 
+  private airPlaySupported: boolean = false;
+  private airPlayAvailable: boolean = false;
+  private airPlayActive: boolean = false;
+
   constructor() {
     this.audioInstance = this.createAudioInstance();
+    this.airPlaySupported = this.supportsAirPlayPicker(this.audioInstance.audio);
+    this.updateAirPlayStateFromAudio(this.audioInstance.audio);
     this.setupAudioEvents(this.audioInstance);
     this.setupMediaSession();
     this.queueService = new PlayQueueService({
@@ -191,12 +201,51 @@ export class AudioPlayerService {
     });
 
     audio.addEventListener('loadstart', () => {
+      this.updateAirPlayStateFromAudio(audio);
       this.emit('loadstart', {});
     });
 
     audio.addEventListener('canplay', () => {
+      this.updateAirPlayStateFromAudio(audio);
       this.emit('canplay', {});
     });
+
+    if (this.supportsAirPlayPicker(audio)) {
+      audio.addEventListener('webkitplaybacktargetavailabilitychanged', (event) => {
+        const availability = (event as WebKitPlaybackTargetAvailabilityEvent).availability;
+        this.updateAirPlayStateFromAudio(audio, availability);
+      });
+
+      audio.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', () => {
+        this.updateAirPlayStateFromAudio(audio);
+      });
+    }
+  }
+
+  private supportsAirPlayPicker(audio: HTMLAudioElement): audio is HTMLAudioElement & { webkitShowPlaybackTargetPicker: () => void } {
+    return typeof audio.webkitShowPlaybackTargetPicker === 'function';
+  }
+
+  private updateAirPlayStateFromAudio(audio: HTMLAudioElement, availability?: string): void {
+    const previousSupported = this.airPlaySupported;
+    const previousAvailable = this.airPlayAvailable;
+    const previousActive = this.airPlayActive;
+
+    this.airPlaySupported = this.supportsAirPlayPicker(audio);
+    this.airPlayAvailable = this.airPlaySupported && availability === 'available';
+    this.airPlayActive = this.airPlaySupported && audio.webkitCurrentPlaybackTargetIsWireless === true;
+
+    if (
+      previousSupported !== this.airPlaySupported
+      || previousAvailable !== this.airPlayAvailable
+      || previousActive !== this.airPlayActive
+    ) {
+      this.emit('airplayavailabilitychange', {
+        airPlaySupported: this.airPlaySupported,
+        airPlayAvailable: this.airPlayAvailable,
+        airPlayActive: this.airPlayActive,
+      });
+    }
   }
 
   private setupMediaSession(): void {
@@ -801,6 +850,23 @@ export class AudioPlayerService {
 
   toggleMute(): void {
     this.setMuted(!this.isMuted);
+  }
+
+  isAirPlaySupported(): boolean {
+    return this.airPlaySupported;
+  }
+
+  isAirPlayAvailable(): boolean {
+    return this.airPlayAvailable;
+  }
+
+  isAirPlayActive(): boolean {
+    return this.airPlayActive;
+  }
+
+  showAirPlayPicker(): void {
+    if (!this.supportsAirPlayPicker(this.audio)) return;
+    this.audio.webkitShowPlaybackTargetPicker();
   }
 
   setShuffle(enabled: boolean): void {

--- a/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
@@ -17,6 +17,17 @@ Object.defineProperty(window.HTMLMediaElement.prototype, 'load', {
   value: vi.fn(),
 });
 
+Object.defineProperty(window.HTMLMediaElement.prototype, 'webkitShowPlaybackTargetPicker', {
+  configurable: true,
+  value: vi.fn(),
+});
+
+Object.defineProperty(window.HTMLMediaElement.prototype, 'webkitCurrentPlaybackTargetIsWireless', {
+  configurable: true,
+  writable: true,
+  value: false,
+});
+
 // Mock URL.createObjectURL and revokeObjectURL
 globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
 globalThis.URL.revokeObjectURL = vi.fn();

--- a/Meziantou.MusicApp.WebPlayer/src/styles/main.css
+++ b/Meziantou.MusicApp.WebPlayer/src/styles/main.css
@@ -1538,6 +1538,11 @@ body {
   position: relative;
 }
 
+.airplay-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
 .queue-badge {
   position: absolute;
   top: -4px;

--- a/Meziantou.MusicApp.WebPlayer/src/vite-env.d.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/vite-env.d.ts
@@ -2,3 +2,12 @@
 /// <reference types="vite-plugin-pwa/react" />
 
 declare const __COMMIT_HASH__: string;
+
+interface HTMLMediaElement {
+  webkitShowPlaybackTargetPicker?: () => void;
+  webkitCurrentPlaybackTargetIsWireless?: boolean;
+}
+
+interface WebKitPlaybackTargetAvailabilityEvent extends Event {
+  availability: 'available' | 'not-available';
+}


### PR DESCRIPTION
## Why
Safari on macOS supports native AirPlay routing from media elements, but the WebPlayer had no UI to trigger it. This adds a dedicated control so users can quickly send playback to AirPlay devices.

## What changed
- Added AirPlay support to `AudioPlayerService`:
  - Detects AirPlay capability (`webkitShowPlaybackTargetPicker` support)
  - Tracks availability and active wireless target state
  - Emits `airplayavailabilitychange` updates
  - Exposes `showAirPlayPicker()`
- Extended `useAudioPlayer` state/actions to surface AirPlay support, availability, active state, and picker action to the UI.
- Added an AirPlay button in `PlayerBar` next to queue controls.
  - Button is shown only when AirPlay is currently available.
  - Active state is reflected when playback is on a wireless target.
- Added/updated typings and test mocks for Safari-specific media APIs.
- Added tests for AirPlay availability, active-state updates, and picker invocation.
- Updated WebPlayer README feature list to mention AirPlay support on Safari/macOS.

## Notes for reviewers
- The control is intentionally hidden when unsupported/unavailable to avoid showing non-functional UI on other browsers/platforms.
- I could not run tests in this environment because `npm` and `dotnet` were not available in PATH.