### PR TITLE
Fix restored volume sounding too low after reload

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
@@ -224,4 +224,36 @@ describe('AudioPlayerService Queue Logic', () => {
       // Should be playing Track 2, not a random track
       expect(player.getCurrentTrack()?.id).toBe('2');
     });
-  });});
+  });
+
+  describe('Volume restoration', () => {
+    it('should reset media element volume when AudioContext is initialized', async () => {
+      player.setVolume(0.3);
+
+      const audioBeforePlay = (player as any).audioInstance.audio as HTMLAudioElement;
+      expect(audioBeforePlay.volume).toBeCloseTo(0.09, 5);
+
+      await player.play();
+
+      const audioAfterPlay = (player as any).audioInstance.audio as HTMLAudioElement;
+      expect(audioAfterPlay.volume).toBe(1);
+
+      const gainNode = (player as any).masterGainNode as GainNode;
+      expect(gainNode.gain.value).toBeCloseTo(0.09, 5);
+    });
+
+    it('should keep media element unmuted when using gain-node muting', async () => {
+      player.setMuted(true);
+      const audioBeforePlay = (player as any).audioInstance.audio as HTMLAudioElement;
+      expect(audioBeforePlay.muted).toBe(true);
+
+      await player.play();
+
+      const audioAfterPlay = (player as any).audioInstance.audio as HTMLAudioElement;
+      expect(audioAfterPlay.muted).toBe(false);
+
+      player.toggleMute();
+      expect(audioAfterPlay.muted).toBe(false);
+    });
+  });
+});

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -119,11 +119,10 @@ export class AudioPlayerService {
     this.audioContext = new AudioContext();
     this.masterGainNode = this.audioContext.createGain();
     this.masterGainNode.connect(this.audioContext.destination);
-    // Apply volume respecting the muted state
-    this.masterGainNode.gain.value = this.isMuted ? 0 : this.linearToLogarithmic(this.masterVolume);
 
     // Connect audio element to the audio context
     this.connectAudioInstance(this.audioInstance);
+    this.applyOutputVolume();
 
     // Emit volumechange to sync React state with actual audio player state
     // This ensures the UI reflects the correct volume after AudioContext initialization
@@ -769,15 +768,25 @@ export class AudioPlayerService {
     return linear * linear;
   }
 
+  private applyOutputVolume(): void {
+    const gainValue = this.linearToLogarithmic(this.masterVolume);
+
+    if (this.masterGainNode) {
+      // Keep the media element at full volume when using Web Audio gain to avoid compounding attenuation.
+      this.audioInstance.audio.volume = 1;
+      this.audioInstance.audio.muted = false;
+      this.masterGainNode.gain.value = this.isMuted ? 0 : gainValue;
+      return;
+    }
+
+    // Fallback path before AudioContext initialization.
+    this.audioInstance.audio.muted = this.isMuted;
+    this.audioInstance.audio.volume = Math.min(1, gainValue);
+  }
+
   setVolume(volume: number): void {
     this.masterVolume = Math.max(0, Math.min(2, volume));
-    const gainValue = this.linearToLogarithmic(this.masterVolume);
-    if (this.masterGainNode) {
-      this.masterGainNode.gain.value = this.isMuted ? 0 : gainValue;
-    } else {
-      // Fallback if no audio context
-      this.audioInstance.audio.volume = this.isMuted ? 0 : Math.min(1, gainValue);
-    }
+    this.applyOutputVolume();
     this.emit('volumechange', { volume: this.masterVolume });
   }
 
@@ -787,11 +796,7 @@ export class AudioPlayerService {
 
   setMuted(muted: boolean): void {
     this.isMuted = muted;
-    if (this.masterGainNode) {
-      this.masterGainNode.gain.value = muted ? 0 : this.linearToLogarithmic(this.masterVolume);
-    } else {
-      this.audioInstance.audio.muted = muted;
-    }
+    this.applyOutputVolume();
     this.emit('volumechange', { volume: this.masterVolume });
   }
 

--- a/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
@@ -22,16 +22,29 @@ globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
 globalThis.URL.revokeObjectURL = vi.fn();
 
 // Mock AudioContext
-window.AudioContext = vi.fn().mockImplementation(() => ({
-  createGain: vi.fn().mockReturnValue({
-    connect: vi.fn(),
-    gain: { value: 1 }
-  }),
-  createMediaElementSource: vi.fn().mockReturnValue({
-    connect: vi.fn()
-  }),
-  destination: {}
-}));
+class MockAudioContext {
+  public readonly destination = {};
+  public readonly state: AudioContextState = 'running';
+
+  createGain() {
+    return {
+      connect: vi.fn(),
+      gain: { value: 1 },
+    };
+  }
+
+  createMediaElementSource() {
+    return {
+      connect: vi.fn(),
+    };
+  }
+
+  async resume() {
+    return undefined;
+  }
+}
+
+window.AudioContext = MockAudioContext as unknown as typeof AudioContext;
 
 // Mock fetch
 globalThis.fetch = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Why
Restored volume could sound lower than the slider value after reopening the app. This happened when playback started with a restored non-default volume and the audio path switched from element fallback volume to Web Audio gain.

## What changed
- Centralized volume/mute output logic in `AudioPlayerService` with `applyOutputVolume()`.
- When `AudioContext` is active, the media element is now forced to `volume=1` and `muted=false`, and effective loudness is controlled only by the master gain node.
- Kept the pre-`AudioContext` fallback behavior for element-based volume/mute control.
- Added regression tests that cover:
  - restored non-default volume before and after `AudioContext` initialization,
  - mute behavior consistency when gain-node muting is active.

## Notes for reviewers
This is intentionally behavior-preserving for slider semantics (`0..200` UI, internal `0..2`) and only removes the compounded attenuation path during restoration/startup.

## Validation
I could not run automated tests in this environment because both `npm` and `dotnet` are unavailable (`command not found`).