### PR TITLE
Fix playback order to match the sorted track list

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
@@ -1,12 +1,12 @@
 import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import type { TrackInfo, AppSettings } from '../types';
-import { formatDuration, matchesSearch, debounce } from '../utils';
+import { formatDuration, matchesSearch, debounce, sortTracks } from '../utils';
 import { useApp } from '../hooks';
 import { PlayingIndicator } from './PlayingIndicator';
 import { CoverImage } from './CoverImage';
 
-type SortOption = 'added' | 'title' | 'artist' | 'album';
-type SortDirection = 'asc' | 'desc';
+type SortOption = Parameters<typeof sortTracks>[1];
+type SortDirection = Parameters<typeof sortTracks>[2];
 
 const ITEM_HEIGHT = 56;
 const BUFFER_SIZE = 5;
@@ -39,55 +39,23 @@ export function TrackList() {
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const sortButtonRef = useRef<HTMLButtonElement>(null);
 
-  const filteredTracks = useMemo(() => {
-    const originalTrackOrder = new Map<TrackInfo, number>();
-    currentPlaylistTracks.forEach((track, index) => {
-      originalTrackOrder.set(track, index);
-    });
+  const sortedTracks = useMemo(
+    () => sortTracks(currentPlaylistTracks, sortOption, sortDirection),
+    [currentPlaylistTracks, sortDirection, sortOption]
+  );
 
-    let tracks = currentPlaylistTracks;
-    if (searchQuery) {
-      tracks = tracks.filter(track =>
-        matchesSearch(track.title, searchQuery) ||
-        matchesSearch(track.artists, searchQuery) ||
-        matchesSearch(track.album, searchQuery) ||
-        matchesSearch(track.isrc, searchQuery)
-      );
+  const filteredTracks = useMemo(() => {
+    if (!searchQuery) {
+      return sortedTracks;
     }
 
-    return [...tracks].sort((a, b) => {
-      let res = 0;
-      const originalOrderRes = (originalTrackOrder.get(a) ?? 0) - (originalTrackOrder.get(b) ?? 0);
-
-      switch (sortOption) {
-        case 'title':
-          res = a.title.localeCompare(b.title);
-          break;
-        case 'artist':
-          res = (a.artists || '').localeCompare(b.artists || '');
-          break;
-        case 'album':
-          res = (a.album || '').localeCompare(b.album || '');
-          break;
-        case 'added':
-        default:
-          const dateA = a.addedDate ? new Date(a.addedDate).getTime() : 0;
-          const dateB = b.addedDate ? new Date(b.addedDate).getTime() : 0;
-          res = dateA - dateB;
-          if (res !== 0) {
-            return sortDirection === 'asc' ? res : -res;
-          }
-
-          return originalOrderRes;
-      }
-
-      if (res === 0) {
-        return originalOrderRes;
-      }
-
-      return sortDirection === 'asc' ? res : -res;
-    });
-  }, [currentPlaylistTracks, searchQuery, sortOption, sortDirection]);
+    return sortedTracks.filter(track =>
+      matchesSearch(track.title, searchQuery) ||
+      matchesSearch(track.artists, searchQuery) ||
+      matchesSearch(track.album, searchQuery) ||
+      matchesSearch(track.isrc, searchQuery)
+    );
+  }, [searchQuery, sortedTracks]);
 
   const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -206,7 +174,7 @@ export function TrackList() {
     const isCached = cachedTrackIds.has(track.id);
     const isAvailable = isOnline || isCached;
     if (isAvailable) {
-      playTrack(track, index, currentPlaylistTracks);
+      playTrack(track, index, sortedTracks);
     }
   };
 
@@ -329,7 +297,7 @@ export function TrackList() {
                     if (isPlaying) {
                       playerActions.togglePlayPause();
                     } else {
-                      playTrack(track, originalIndex, currentPlaylistTracks);
+                      playTrack(track, originalIndex, sortedTracks);
                     }
                   }}
                 />
@@ -347,7 +315,7 @@ export function TrackList() {
           index={contextMenu.index}
           isCached={cachedTrackIds.has(contextMenu.track.id)}
           onPlay={() => {
-            playTrack(contextMenu.track, contextMenu.index, currentPlaylistTracks);
+            playTrack(contextMenu.track, contextMenu.index, sortedTracks);
             setContextMenu(null);
           }}
           onAddToQueue={() => {
@@ -700,4 +668,3 @@ function SortMenu({ id, anchorRef, currentOption, currentDirection, onSelect }: 
     </div>
   );
 }
-

--- a/Meziantou.MusicApp.WebPlayer/src/utils/helpers.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/utils/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { matchesSearch, normalizeSearch } from './helpers';
+import type { TrackInfo } from '../types';
+import { matchesSearch, normalizeSearch, sortTracks } from './helpers';
 
 describe('Search Track Feature', () => {
   describe('normalizeSearch', () => {
@@ -191,6 +192,55 @@ describe('Search Track Feature', () => {
         expect(matchesSearch('Track 1', '1')).toBe(true);
         expect(matchesSearch('2023 Album', '2023')).toBe(true);
       });
+    });
+  });
+
+  describe('sortTracks', () => {
+    const createTrack = (id: string, title: string, addedDate: string | null): TrackInfo => ({
+      id,
+      title,
+      path: `/music/${id}.mp3`,
+      artists: null,
+      album: null,
+      duration: 60,
+      artistId: null,
+      albumId: null,
+      track: null,
+      year: null,
+      genre: null,
+      bitRate: null,
+      size: 1000,
+      contentType: 'audio/mpeg',
+      addedDate,
+      isrc: null,
+      replayGainTrackGain: null,
+      replayGainTrackPeak: null,
+      replayGainAlbumGain: null,
+      replayGainAlbumPeak: null,
+    });
+
+    it('should sort by added date descending', () => {
+      const tracks = [
+        createTrack('old', 'Old Track', '2024-01-01T00:00:00Z'),
+        createTrack('new', 'New Track', '2024-03-01T00:00:00Z'),
+        createTrack('mid', 'Mid Track', '2024-02-01T00:00:00Z'),
+      ];
+
+      const sorted = sortTracks(tracks, 'added', 'desc');
+
+      expect(sorted.map(track => track.id)).toEqual(['new', 'mid', 'old']);
+    });
+
+    it('should preserve original order when added dates are equal', () => {
+      const tracks = [
+        createTrack('a', 'Track A', '2024-01-01T00:00:00Z'),
+        createTrack('b', 'Track B', '2024-01-01T00:00:00Z'),
+        createTrack('c', 'Track C', '2024-01-01T00:00:00Z'),
+      ];
+
+      const sorted = sortTracks(tracks, 'added', 'desc');
+
+      expect(sorted.map(track => track.id)).toEqual(['a', 'b', 'c']);
     });
   });
 });

--- a/Meziantou.MusicApp.WebPlayer/src/utils/helpers.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/utils/helpers.ts
@@ -1,5 +1,51 @@
 // Utility functions for DOM manipulation and formatting
 
+import type { TrackInfo } from '../types';
+
+export type TrackSortOption = 'added' | 'title' | 'artist' | 'album';
+export type TrackSortDirection = 'asc' | 'desc';
+
+export function sortTracks(tracks: TrackInfo[], sortOption: TrackSortOption, sortDirection: TrackSortDirection): TrackInfo[] {
+  const originalTrackOrder = new Map<TrackInfo, number>();
+  tracks.forEach((track, index) => {
+    originalTrackOrder.set(track, index);
+  });
+
+  return [...tracks].sort((a, b) => {
+    let res = 0;
+    const originalOrderRes = (originalTrackOrder.get(a) ?? 0) - (originalTrackOrder.get(b) ?? 0);
+
+    switch (sortOption) {
+      case 'title':
+        res = a.title.localeCompare(b.title);
+        break;
+      case 'artist':
+        res = (a.artists || '').localeCompare(b.artists || '');
+        break;
+      case 'album':
+        res = (a.album || '').localeCompare(b.album || '');
+        break;
+      case 'added':
+      default: {
+        const dateA = a.addedDate ? new Date(a.addedDate).getTime() : 0;
+        const dateB = b.addedDate ? new Date(b.addedDate).getTime() : 0;
+        res = dateA - dateB;
+        if (res !== 0) {
+          return sortDirection === 'asc' ? res : -res;
+        }
+
+        return originalOrderRes;
+      }
+    }
+
+    if (res === 0) {
+      return originalOrderRes;
+    }
+
+    return sortDirection === 'asc' ? res : -res;
+  });
+}
+
 export function formatDuration(seconds: number): string {
   if (!seconds || !isFinite(seconds)) return '0:00';
 


### PR DESCRIPTION
## Why
Playback order could diverge from what users see in the track list. For example, with `Added Date` sorting, starting playback from the list could continue in a different underlying order, which made next/previous behavior feel inverted.

## What changed
- Reused a single sorting implementation for track list display and playback queue initialization.
- Updated `TrackList` to:
  - build a `sortedTracks` list from the selected sort option/direction,
  - apply search filtering on top of that sorted list for display,
  - pass `sortedTracks` to playback actions (double-click, play button, context menu play).
- Added regression tests for sorting behavior in `helpers.test.ts`, including:
  - added-date descending order,
  - stable fallback to original order when added dates are equal.

## Notes
- Search filtering now affects only what is visible, not queue scope: playback still uses the full playlist in selected sort order.
- WebPlayer tests and build pass in this environment.
- `dotnet test` could not be run here because `dotnet` is not installed.