### PR TITLE
Reduce memory footprint: idle-release audio, LRU cover art, deferred preload, smaller queue

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
@@ -25,6 +25,17 @@ export function CoverImage({
   const [coverSrc, setCoverSrc] = useState(COVER_PLACEHOLDER_DATA_URI);
   const coverBlobUrlRef = useRef<string | null>(null);
 
+  // Always revoke any blob URL on unmount so virtualized rows don't leak
+  // when they scroll out of view without re-running the main effect.
+  useEffect(() => {
+    return () => {
+      if (coverBlobUrlRef.current && coverBlobUrlRef.current.startsWith('blob:')) {
+        URL.revokeObjectURL(coverBlobUrlRef.current);
+        coverBlobUrlRef.current = null;
+      }
+    };
+  }, []);
+
   useEffect(() => {
     // Cleanup previous blob URL
     if (coverBlobUrlRef.current && coverBlobUrlRef.current.startsWith('blob:')) {

--- a/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import type { TrackInfo, AppSettings } from '../types';
-import { formatDuration, matchesSearch, debounce, sortTracks } from '../utils';
+import { formatDuration, normalizeSearch, debounce, sortTracks } from '../utils';
 import { useApp } from '../hooks';
 import { getApiService } from '../services';
 import { PlayingIndicator } from './PlayingIndicator';
@@ -60,18 +60,43 @@ export function TrackList() {
     [currentPlaylistTracks, sortDirection, sortOption]
   );
 
+  // Precomputed normalized search text per sorted track. Built once per
+  // playlist/sort so each keystroke is a cheap string.includes scan instead
+  // of re-normalizing every searchable field on every track.
+  const searchHaystacks = useMemo(() => {
+    const out = new Array<string>(sortedTracks.length);
+    for (let i = 0; i < sortedTracks.length; i++) {
+      const t = sortedTracks[i];
+      out[i] = normalizeSearch(
+        `${t.title}\n${t.artists ?? ''}\n${t.album ?? ''}\n${t.isrc ?? ''}`
+      );
+    }
+    return out;
+  }, [sortedTracks]);
+
   const filteredTracks = useMemo(() => {
     if (!searchQuery) {
       return sortedTracks;
     }
 
-    return sortedTracks.filter(track =>
-      matchesSearch(track.title, searchQuery) ||
-      matchesSearch(track.artists, searchQuery) ||
-      matchesSearch(track.album, searchQuery) ||
-      matchesSearch(track.isrc, searchQuery)
-    );
-  }, [searchQuery, sortedTracks]);
+    const normalizedQuery = normalizeSearch(searchQuery);
+    if (!normalizedQuery) return sortedTracks;
+    const queryFragments = normalizedQuery.split(' ');
+
+    const out: TrackInfo[] = [];
+    for (let i = 0; i < sortedTracks.length; i++) {
+      const haystack = searchHaystacks[i];
+      let matches = true;
+      for (let j = 0; j < queryFragments.length; j++) {
+        if (!haystack.includes(queryFragments[j])) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) out.push(sortedTracks[i]);
+    }
+    return out;
+  }, [searchQuery, sortedTracks, searchHaystacks]);
 
   const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, useMemo, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import type {
   AppSettings,
   PlaylistSummary,
@@ -93,7 +93,13 @@ export function AppProvider({ children }: AppProviderProps) {
   const [networkType, setNetworkType] = useState(getNetworkType());
   const [cachedTrackIds, setCachedTrackIds] = useState<Set<string>>(new Set());
   const [offlinePlaylistIds, setOfflinePlaylistIds] = useState<Set<string>>(new Set());
-  const [offlinePlaylistTracks, setOfflinePlaylistTracks] = useState<Map<string, string[]>>(new Map());
+  // Progress is stored directly as {cached,total} so we never have to keep the
+  // full track-id list of every offline playlist in React state. Initial values
+  // are computed once when the offline playlist is loaded; subsequent download
+  // completions bump `cached` incrementally via the downloadService.onProgress
+  // handler below.
+  const [playlistDownloadProgress, setPlaylistDownloadProgress] =
+    useState<Map<string, { cached: number; total: number }>>(new Map());
   const [loadingCount, setLoadingCount] = useState(0);
   const isLoading = loadingCount > 0;
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
@@ -105,16 +111,6 @@ export function AppProvider({ children }: AppProviderProps) {
   const setIsLoading = useCallback((loading: boolean) => {
     setLoadingCount(prev => Math.max(0, prev + (loading ? 1 : -1)));
   }, []);
-
-  // Compute playlist download progress dynamically from track lists and cached IDs
-  const playlistDownloadProgress = useMemo(() => {
-    const progress = new Map<string, { cached: number; total: number }>();
-    for (const [playlistId, trackIds] of offlinePlaylistTracks) {
-      const cachedCount = trackIds.filter(id => cachedTrackIds.has(id)).length;
-      progress.set(playlistId, { cached: cachedCount, total: trackIds.length });
-    }
-    return progress;
-  }, [offlinePlaylistTracks, cachedTrackIds]);
 
   const showToast = useCallback((message: string, type: 'info' | 'error' | 'success' = 'info') => {
     const id = Date.now();
@@ -207,15 +203,21 @@ export function AppProvider({ children }: AppProviderProps) {
           currentPlaylists = cachedPlaylists.map(cp => cp.playlist).sort((a, b) => a.sortOrder - b.sortOrder);
           setPlaylists(currentPlaylists);
 
-          // Set up track lists for offline playlists
+          // Set up download progress for offline playlists.
+          // Computing once here avoids keeping the full track-id list in React state.
           const offlinePls = await storageService.getOfflinePlaylistIds();
-          const trackLists = new Map<string, string[]>();
+          const cached = await storageService.getCachedTrackIds();
+          const progressMap = new Map<string, { cached: number; total: number }>();
           for (const cachedPl of cachedPlaylists) {
             if (offlinePls.has(cachedPl.playlist.id)) {
-              trackLists.set(cachedPl.playlist.id, cachedPl.tracks.map(t => t.id));
+              let cachedCount = 0;
+              for (const t of cachedPl.tracks) {
+                if (cached.has(t.id)) cachedCount++;
+              }
+              progressMap.set(cachedPl.playlist.id, { cached: cachedCount, total: cachedPl.tracks.length });
             }
           }
-          setOfflinePlaylistTracks(trackLists);
+          setPlaylistDownloadProgress(progressMap);
         }
 
         // Restore playback state
@@ -361,7 +363,26 @@ export function AppProvider({ children }: AppProviderProps) {
   useEffect(() => {
     const unsubscribe = downloadService.onProgress((progress) => {
       if (progress.status === 'complete') {
-        setCachedTrackIds(prev => new Set([...prev, progress.trackId]));
+        setCachedTrackIds(prev => {
+          if (prev.has(progress.trackId)) return prev;
+          const next = new Set(prev);
+          next.add(progress.trackId);
+          return next;
+        });
+        if (progress.playlistIds && progress.playlistIds.length > 0) {
+          setPlaylistDownloadProgress(prev => {
+            let mutated = false;
+            const next = new Map(prev);
+            for (const pid of progress.playlistIds!) {
+              const entry = next.get(pid);
+              if (entry && entry.cached < entry.total) {
+                next.set(pid, { cached: entry.cached + 1, total: entry.total });
+                mutated = true;
+              }
+            }
+            return mutated ? next : prev;
+          });
+        }
       } else if (progress.status === 'error') {
         showToast(`Download failed: ${progress.error}`, 'error');
       }
@@ -447,8 +468,9 @@ export function AppProvider({ children }: AppProviderProps) {
             });
           }
 
-          // Remove from offline playlist tracks
-          setOfflinePlaylistTracks(prev => {
+          // Remove from offline playlist progress tracking
+          setPlaylistDownloadProgress(prev => {
+            if (!prev.has(cachedPlaylist.playlist.id)) return prev;
             const next = new Map(prev);
             next.delete(cachedPlaylist.playlist.id);
             return next;
@@ -468,12 +490,19 @@ export function AppProvider({ children }: AppProviderProps) {
             const tracksResponse = await api.getPlaylistTracks(playlist.id);
             await storageService.saveCachedPlaylist(playlist, tracksResponse.tracks);
 
-            // Update track list for progress calculation
-            setOfflinePlaylistTracks(prev => {
-              const next = new Map(prev);
-              next.set(playlist.id, tracksResponse.tracks.map(t => t.id));
-              return next;
-            });
+            // Recompute download progress for this playlist
+            {
+              let cachedCount = 0;
+              for (const t of tracksResponse.tracks) {
+                if (cachedTrackIds.has(t.id)) cachedCount++;
+              }
+              const total = tracksResponse.tracks.length;
+              setPlaylistDownloadProgress(prev => {
+                const next = new Map(prev);
+                next.set(playlist.id, { cached: cachedCount, total });
+                return next;
+              });
+            }
 
             // Queue downloads for uncached tracks
             const uncachedTracks = tracksResponse.tracks.filter(t => !cachedTrackIds.has(t.id));
@@ -494,12 +523,21 @@ export function AppProvider({ children }: AppProviderProps) {
               setCurrentPlaylistTracks(tracksResponse.tracks);
             }
           } else if (cached) {
-            // Playlist hasn't changed, but ensure track list is set for progress
-            setOfflinePlaylistTracks(prev => {
-              const next = new Map(prev);
-              next.set(playlist.id, cached.tracks.map(t => t.id));
-              return next;
-            });
+            // Playlist hasn't changed, but ensure progress is initialized.
+            {
+              let cachedCount = 0;
+              for (const t of cached.tracks) {
+                if (cachedTrackIds.has(t.id)) cachedCount++;
+              }
+              const total = cached.tracks.length;
+              setPlaylistDownloadProgress(prev => {
+                const existing = prev.get(playlist.id);
+                if (existing && existing.cached === cachedCount && existing.total === total) return prev;
+                const next = new Map(prev);
+                next.set(playlist.id, { cached: cachedCount, total });
+                return next;
+              });
+            }
 
             // Also check for uncached tracks (in case previous downloads were interrupted)
             const uncachedTracks = cached.tracks.filter(t => !cachedTrackIds.has(t.id));
@@ -717,12 +755,32 @@ export function AppProvider({ children }: AppProviderProps) {
   }, [currentPlaylistId, settings.downloadQuality, showToast]);
 
   const deleteDownloadedTrack = useCallback(async (track: TrackInfo) => {
+    // Capture playlistIds before deletion so we can decrement the per-playlist
+    // progress counters for each affected offline playlist.
+    const before = await storageService.getCachedTrack(track.id);
+    const affectedPlaylistIds = before?.playlistIds ?? [];
+
     await downloadService.deleteTrack(track.id);
     setCachedTrackIds(prev => {
+      if (!prev.has(track.id)) return prev;
       const next = new Set(prev);
       next.delete(track.id);
       return next;
     });
+    if (affectedPlaylistIds.length > 0) {
+      setPlaylistDownloadProgress(prev => {
+        let mutated = false;
+        const next = new Map(prev);
+        for (const pid of affectedPlaylistIds) {
+          const entry = next.get(pid);
+          if (entry && entry.cached > 0) {
+            next.set(pid, { cached: entry.cached - 1, total: entry.total });
+            mutated = true;
+          }
+        }
+        return mutated ? next : prev;
+      });
+    }
     showToast(`Removed "${track.title}" from downloads`);
   }, [showToast]);
 
@@ -731,7 +789,7 @@ export function AppProvider({ children }: AppProviderProps) {
     setCachedTrackIds(new Set());
     playerActions.setCachedTrackIds(new Set());
     setOfflinePlaylistIds(new Set());
-    setOfflinePlaylistTracks(new Map());
+    setPlaylistDownloadProgress(new Map());
     downloadService.clearQueue();
     showToast('All cached data cleared');
   }, [playerActions, showToast]);
@@ -782,11 +840,16 @@ export function AppProvider({ children }: AppProviderProps) {
         setCurrentPlaylistTracks(updated.tracks);
       }
 
-      // If this playlist is marked for offline, update track list and download the new track
+      // If this playlist is marked for offline, refresh progress and download the new track
       if (offlinePlaylistIds.has(playlist.id)) {
-        setOfflinePlaylistTracks(prev => {
+        let cachedCount = 0;
+        for (const t of updated.tracks) {
+          if (cachedTrackIds.has(t.id)) cachedCount++;
+        }
+        const total = updated.tracks.length;
+        setPlaylistDownloadProgress(prev => {
           const next = new Map(prev);
-          next.set(playlist.id, updated.tracks.map(t => t.id));
+          next.set(playlist.id, { cached: cachedCount, total });
           return next;
         });
 
@@ -857,9 +920,14 @@ export function AppProvider({ children }: AppProviderProps) {
       }
 
       if (offlinePlaylistIds.has(playlistId)) {
-        setOfflinePlaylistTracks(prev => {
+        let cachedCount = 0;
+        for (const t of updated.tracks) {
+          if (cachedTrackIds.has(t.id)) cachedCount++;
+        }
+        const total = updated.tracks.length;
+        setPlaylistDownloadProgress(prev => {
           const next = new Map(prev);
-          next.set(playlistId, updated.tracks.map(t => t.id));
+          next.set(playlistId, { cached: cachedCount, total });
           return next;
         });
       }
@@ -871,7 +939,7 @@ export function AppProvider({ children }: AppProviderProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [isOnline, settings.serverUrl, currentPlaylistId, currentPlaylistTracks, playlists, offlinePlaylistIds, showToast]);
+  }, [isOnline, settings.serverUrl, currentPlaylistId, currentPlaylistTracks, playlists, offlinePlaylistIds, cachedTrackIds, showToast]);
 
   const testConnection = useCallback(async () => {
     try {
@@ -1009,7 +1077,8 @@ export function AppProvider({ children }: AppProviderProps) {
           next.delete(playlistId);
           return next;
         });
-        setOfflinePlaylistTracks(prev => {
+        setPlaylistDownloadProgress(prev => {
+          if (!prev.has(playlistId)) return prev;
           const next = new Map(prev);
           next.delete(playlistId);
           return next;
@@ -1048,15 +1117,6 @@ export function AppProvider({ children }: AppProviderProps) {
     }
   }, [isOnline, settings.serverUrl, playlists, currentPlaylistId, playingPlaylistId, offlinePlaylistIds, playerActions, showToast]);
 
-  // Helper to update offline playlist track list
-  const setPlaylistTrackList = useCallback((playlistId: string, tracks: TrackInfo[]) => {
-    setOfflinePlaylistTracks(prev => {
-      const next = new Map(prev);
-      next.set(playlistId, tracks.map(t => t.id));
-      return next;
-    });
-  }, []);
-
   // Start caching a playlist for offline use
   const startPlaylistCaching = useCallback(async (playlistId: string) => {
     if (!isOnline) {
@@ -1085,8 +1145,17 @@ export function AppProvider({ children }: AppProviderProps) {
       return;
     }
 
-    // Set track list for progress calculation
-    setPlaylistTrackList(playlistId, tracks);
+    // Initialize progress for this playlist
+    let cachedCount = 0;
+    for (const t of tracks) {
+      if (cachedTrackIds.has(t.id)) cachedCount++;
+    }
+    const total = tracks.length;
+    setPlaylistDownloadProgress(prev => {
+      const next = new Map(prev);
+      next.set(playlistId, { cached: cachedCount, total });
+      return next;
+    });
 
     // Queue all tracks for download
     const uncachedTracks = tracks.filter(t => !cachedTrackIds.has(t.id));
@@ -1097,7 +1166,7 @@ export function AppProvider({ children }: AppProviderProps) {
 
     showToast(`Downloading ${uncachedTracks.length} tracks...`);
     await downloadService.queuePlaylistDownload(uncachedTracks, playlistId, settings.downloadQuality);
-  }, [isOnline, playlists, cachedTrackIds, settings.downloadQuality, showToast, setPlaylistTrackList]);
+  }, [isOnline, playlists, cachedTrackIds, settings.downloadQuality, showToast]);
 
   // Stop caching a playlist and optionally delete cached tracks
   const stopPlaylistCaching = useCallback(async (playlistId: string) => {
@@ -1126,8 +1195,9 @@ export function AppProvider({ children }: AppProviderProps) {
     const cached = await storageService.getCachedTrackIds();
     setCachedTrackIds(cached);
 
-    // Remove from track list tracking
-    setOfflinePlaylistTracks(prev => {
+    // Remove from progress tracking
+    setPlaylistDownloadProgress(prev => {
+      if (!prev.has(playlistId)) return prev;
       const next = new Map(prev);
       next.delete(playlistId);
       return next;

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -64,6 +64,11 @@ export class AudioPlayerService {
   private preloadBlobUrl: string | null = null;
   private preloadAbortController: AbortController | null = null;
 
+  // Idle-release state: free the audio Blob URL after a long pause.
+  private idleReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+  private isIdleReleased: boolean = false;
+  private static readonly IDLE_RELEASE_MS = 5 * 60 * 1000; // 5 minutes
+
   // Volume state
   private masterVolume: number = 1;
   private isMuted: boolean = false;
@@ -152,6 +157,7 @@ export class AudioPlayerService {
     const audio = instance.audio;
 
     audio.addEventListener('play', () => {
+      this.cancelIdleRelease();
       this.emit('play', {});
       if (!this.hasSentNowPlaying && this.currentTrack) {
         this.hasSentNowPlaying = true;
@@ -160,6 +166,7 @@ export class AudioPlayerService {
     });
 
     audio.addEventListener('pause', () => {
+      this.scheduleIdleRelease();
       this.emit('pause', {});
     });
 
@@ -395,14 +402,90 @@ export class AudioPlayerService {
     }
   }
 
+  // Idle-release helpers: free the audio Blob URL after a long pause to release
+  // the underlying bytes back to the GC. The track and timestamp are kept on
+  // this.currentTrack / this.idleReleasedTime so play() can transparently reload.
+
+  private idleReleasedTime: number = 0;
+
+  private scheduleIdleRelease(): void {
+    if (this.idleReleaseTimer) return;
+    if (this.isIdleReleased) return;
+    this.idleReleaseTimer = setTimeout(() => {
+      this.idleReleaseTimer = null;
+      this.releaseLoadedAudioMemory();
+    }, AudioPlayerService.IDLE_RELEASE_MS);
+  }
+
+  private cancelIdleRelease(): void {
+    if (this.idleReleaseTimer) {
+      clearTimeout(this.idleReleaseTimer);
+      this.idleReleaseTimer = null;
+    }
+  }
+
+  private releaseLoadedAudioMemory(): void {
+    if (this.isIdleReleased) return;
+    if (!this.audio.paused) return; // safety: only release when paused
+
+    this.idleReleasedTime = this.audio.currentTime;
+
+    const active = this.activeInstance;
+    if (active.audio.src) {
+      // Revoke the blob URL so the underlying Blob can be GC'd.
+      const src = active.audio.src;
+      active.audio.removeAttribute('src');
+      active.audio.load(); // force the element to drop its buffered bytes
+      if (src.startsWith('blob:')) {
+        URL.revokeObjectURL(src);
+      }
+    }
+
+    if (this.preloadBlobUrl) {
+      URL.revokeObjectURL(this.preloadBlobUrl);
+      this.preloadBlobUrl = null;
+    }
+    if (this.preloadAbortController) {
+      this.preloadAbortController.abort();
+      this.preloadAbortController = null;
+    }
+    this.preloadedTrack = null;
+    this.isPreloading = false;
+
+    this.isIdleReleased = true;
+  }
+
+  private async restoreFromIdleReleaseIfNeeded(): Promise<void> {
+    if (!this.isIdleReleased) return;
+    const track = this.currentTrack;
+    this.isIdleReleased = false;
+    if (!track) return;
+    await this.loadTrack(track, false, this.idleReleasedTime);
+  }
+
   // Preloading methods
+
+  // Only preload the next track when the current one is near the end.
+  // Holding two full audio Blobs at once is a major source of RAM use; deferring
+  // preload to the last ~30s (or 10% of duration) keeps just one blob in memory
+  // for most of the playback window.
+  private static readonly PRELOAD_TAIL_SECONDS = 30;
+  private static readonly PRELOAD_TAIL_FRACTION = 0.1;
 
   private checkForPreload(): void {
     if (this.isPreloading || this.preloadedTrack) return;
 
     const duration = this.audio.duration;
+    const currentTime = this.audio.currentTime;
 
-    if (!duration || isNaN(duration)) return;
+    if (!duration || isNaN(duration) || !isFinite(duration)) return;
+
+    const remaining = duration - currentTime;
+    const tailWindow = Math.min(
+      AudioPlayerService.PRELOAD_TAIL_SECONDS,
+      duration * AudioPlayerService.PRELOAD_TAIL_FRACTION
+    );
+    if (remaining > tailWindow) return;
 
     this.preloadNextTrack();
   }
@@ -483,6 +566,10 @@ export class AudioPlayerService {
   }
 
   private async loadTrack(track: TrackInfo, autoPlay: boolean = false, startTime: number = 0): Promise<void> {
+    // Loading a new track invalidates any pending idle release.
+    this.cancelIdleRelease();
+    this.isIdleReleased = false;
+
     // Cancel any ongoing preload
     if (this.preloadAbortController) {
       this.preloadAbortController.abort();
@@ -725,6 +812,8 @@ export class AudioPlayerService {
   }
 
   async play(): Promise<void> {
+    this.cancelIdleRelease();
+    await this.restoreFromIdleReleaseIfNeeded();
     if (!this.audioContext) {
       await this.initAudioContext();
     }
@@ -807,6 +896,12 @@ export class AudioPlayerService {
   }
 
   seek(time: number): void {
+    // While idle-released the audio element has no src; just remember where the
+    // user seeked to so the next play() resumes from there.
+    if (this.isIdleReleased) {
+      this.idleReleasedTime = Math.max(0, time);
+      return;
+    }
     this.audio.currentTime = Math.max(0, Math.min(time, this.audio.duration || 0));
     this.updatePositionState();
   }

--- a/Meziantou.MusicApp.WebPlayer/src/services/download-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/download-service.ts
@@ -7,6 +7,8 @@ export interface DownloadProgress {
   progress: number; // 0-1
   status: 'pending' | 'downloading' | 'complete' | 'error';
   error?: string;
+  /** Playlists this track belongs to. Populated for 'complete' events so subscribers can update per-playlist progress without scanning every playlist's track list. */
+  playlistIds?: string[];
 }
 
 type DownloadCallback = (progress: DownloadProgress) => void;
@@ -180,7 +182,7 @@ class DownloadService {
       }
 
       this.cachedTrackIds.add(track.id);
-      this.notifyProgress({ trackId: track.id, progress: 1, status: 'complete' });
+      this.notifyProgress({ trackId: track.id, progress: 1, status: 'complete', playlistIds });
     } catch (error) {
       this.notifyProgress({ 
         trackId: track.id, 

--- a/Meziantou.MusicApp.WebPlayer/src/services/play-queue-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/play-queue-service.ts
@@ -27,10 +27,10 @@ export class PlayQueueService {
   private config: QueueConfig;
 
   // Constants
-  private static readonly MAX_QUEUE_SIZE = 500;
-  private static readonly MIN_LOOKAHEAD = 100;
-  private static readonly KEEP_HISTORY_ITEMS = 50; // When trimming, keep this many items before current
-  private static readonly KEEP_LOOKAHEAD_ITEMS = 100; // When trimming, keep this many items after current
+  private static readonly MAX_QUEUE_SIZE = 200;
+  private static readonly MIN_LOOKAHEAD = 20;
+  private static readonly KEEP_HISTORY_ITEMS = 20; // When trimming, keep this many items before current
+  private static readonly KEEP_LOOKAHEAD_ITEMS = 30; // When trimming, keep this many items after current
   private static readonly MAX_LOOP_OFFSET = 10;
 
   constructor(config: QueueConfig) {

--- a/Meziantou.MusicApp.WebPlayer/src/services/storage-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/storage-service.ts
@@ -79,6 +79,7 @@ const DB_VERSION = 6;
 class StorageService {
   private db: IDBPDatabase<MusicPlayerDB> | null = null;
   private initPromise: Promise<IDBPDatabase<MusicPlayerDB>> | null = null;
+  private coverSavesSinceEviction = 0;
 
   async init(): Promise<IDBPDatabase<MusicPlayerDB>> {
     if (this.db) return this.db;
@@ -160,6 +161,12 @@ class StorageService {
     });
 
     this.db = await this.initPromise;
+
+    // One-shot maintenance after init: evict any oversized cover-art cache from earlier versions.
+    // Best-effort; do not block init or surface errors.
+    this.evictOldCachedCovers().catch(err => console.warn('Cover LRU eviction failed:', err));
+    this.cleanupOldRecentlyPlayed(300).catch(err => console.warn('Recently-played cleanup failed:', err));
+
     return this.db;
   }
 
@@ -367,9 +374,16 @@ class StorageService {
   }
 
   // Cover Art
+  static readonly COVER_ART_MAX_ENTRIES = 300;
+
   async getCachedCover(trackId: string): Promise<Blob | undefined> {
     const db = await this.init();
     const entry = await db.get('coverArt', trackId);
+    if (entry) {
+      // Refresh cachedAt so frequently-used covers are kept by LRU eviction.
+      // Don't await; this is a background hint.
+      db.put('coverArt', { trackId, blob: entry.blob, cachedAt: Date.now() }).catch(() => { /* best-effort */ });
+    }
     return entry?.blob;
   }
 
@@ -380,6 +394,54 @@ class StorageService {
       blob,
       cachedAt: Date.now()
     });
+
+    // Amortize LRU eviction every N saves to avoid scanning the store on every write.
+    this.coverSavesSinceEviction++;
+    if (this.coverSavesSinceEviction >= 50) {
+      this.coverSavesSinceEviction = 0;
+      this.evictOldCachedCovers().catch(err => console.warn('Cover LRU eviction failed:', err));
+    }
+  }
+
+  async evictOldCachedCovers(maxEntries: number = StorageService.COVER_ART_MAX_ENTRIES): Promise<void> {
+    const db = await this.init();
+
+    // Cheap pre-check: nothing to do if total already fits the cap.
+    if ((await db.count('coverArt')) <= maxEntries) return;
+
+    // Covers for tracks that are downloaded for offline use are protected:
+    // evicting them would leave a downloaded playlist with missing artwork.
+    const protectedIds = await db.getAllKeys('cachedTracks');
+    const protectedSet = new Set(protectedIds as string[]);
+
+    const tx = db.transaction('coverArt', 'readwrite');
+    const store = tx.objectStore('coverArt');
+
+    const evictable: { trackId: string; cachedAt: number }[] = [];
+    let cursor = await store.openCursor();
+    while (cursor) {
+      const trackId = cursor.value.trackId;
+      if (!protectedSet.has(trackId)) {
+        evictable.push({ trackId, cachedAt: cursor.value.cachedAt ?? 0 });
+      }
+      cursor = await cursor.continue();
+    }
+
+    // Budget for non-protected covers. If protected covers alone already exceed
+    // the cap, evict every non-protected cover but leave protected ones intact.
+    const protectedCount = (await store.count()) - evictable.length;
+    const evictableBudget = Math.max(0, maxEntries - protectedCount);
+    const toDelete = evictable.length - evictableBudget;
+    if (toDelete <= 0) {
+      await tx.done;
+      return;
+    }
+
+    evictable.sort((a, b) => a.cachedAt - b.cachedAt);
+    for (let i = 0; i < toDelete; i++) {
+      await store.delete(evictable[i].trackId);
+    }
+    await tx.done;
   }
 
   // Offline Playlists (marking playlists for offline caching)

--- a/Meziantou.MusicApp.WebPlayer/vite.config.ts
+++ b/Meziantou.MusicApp.WebPlayer/vite.config.ts
@@ -87,26 +87,14 @@ export default defineConfig({
         ]
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-        runtimeCaching: [
-          {
-            urlPattern: /^https?:\/\/.*\/api\/songs\/.*\/cover/,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'cover-art-cache',
-              expiration: {
-                maxEntries: 500,
-                maxAgeSeconds: 60 * 60 * 24 * 30 // 30 days
-              }
-            }
-          }
-        ]
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}']
+        // Cover art is cached in IndexedDB by storage-service; no runtime SW cache to avoid duplicating storage and RAM pressure.
       }
     })
   ],
   build: {
     target: 'esnext',
-    sourcemap: true
+    sourcemap: process.env.NODE_ENV !== 'production'
   },
   server: {
     port: 3000


### PR DESCRIPTION
## Motivation

The web player was holding more memory than necessary during typical use: audio blobs stayed loaded indefinitely after pausing, two full audio blobs could be resident at once during preloading, the cover-art cache had no size bound, the play queue could grow very large, and offline playlist progress tracking kept full track-ID arrays in React state.

## What changed

### Audio playback (`audio-player.ts`)
- **Idle-release**: after 5 minutes of being paused, the audio Blob URL is revoked and the `<audio>` element's `src` is cleared, freeing the underlying bytes for GC. The track metadata and playback position are preserved, so calling `play()` transparently reloads and resumes from where it left off. `seek()` while idle-released is also handled.
- **Deferred preload**: the next track is now only preloaded in the last 30 s (or last 10% of duration), instead of immediately after the current track starts. This keeps at most one large audio blob in RAM for the vast majority of a track's lifetime.

### Cover-art cache (`storage-service.ts`)
- Added LRU eviction capped at 300 entries. Covers for tracks cached for offline use are protected and never evicted.
- Eviction runs once at startup (one-shot, best-effort) and again every 50 saves during a session.
- `getCachedCover` now refreshes `cachedAt` on reads so frequently-accessed covers naturally survive eviction.
- Old `recentlyPlayed` entries are also pruned at startup (kept to 300).

### Play queue (`play-queue-service.ts`)
Reduced the in-memory queue size constants:

| Constant | Before | After |
|---|---|---|
| `MAX_QUEUE_SIZE` | 500 | 200 |
| `MIN_LOOKAHEAD` | 100 | 20 |
| `KEEP_HISTORY_ITEMS` | 50 | 20 |
| `KEEP_LOOKAHEAD_ITEMS` | 100 | 30 |

### Offline playlist progress (`useApp.tsx` + `download-service.ts`)
- Replaced `offlinePlaylistTracks: Map<string, string[]>` (full track-ID arrays in React state, recomputed with a `useMemo` scan on every download event) with `playlistDownloadProgress: Map<string, {cached, total}>`.
- `DownloadProgress` now carries `playlistIds` on `'complete'` events, enabling O(1) incremental counter bumps instead of a full scan.
- All state mutations now bail out early (returning the previous reference) when nothing actually changed, avoiding unnecessary re-renders.

### Search (`TrackList.tsx`)
- Normalized search haystacks are precomputed once per playlist/sort into a flat string array, so each keystroke scans pre-normalized strings rather than re-normalizing every field on every track.
- Search now uses multi-word AND logic: all space-separated fragments must be present in the haystack.

### Blob URL leak fix (`CoverImage.tsx`)
- Added a dedicated unmount cleanup effect that always revokes blob URLs. Virtualized rows scrolling out of view were previously leaking blob URLs because the main effect's cleanup only ran when the `trackId` prop changed.

### Build config (`vite.config.ts`)
- Removed the Service Worker runtime cache for cover art -- covers are now managed entirely in IndexedDB by `StorageService`, eliminating a second copy in the SW cache.
- Source maps are now disabled in production builds to reduce bundle size.