### PR TITLE
Support PNG/JPG/WebP/AVIF cover art in REST API and Web Player

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
@@ -180,4 +180,79 @@ public class RestApiIntegrationTests
                 }
             """);
     }
+
+    [Theory]
+    [InlineData("song", "cover.png", "image/png")]
+    [InlineData("song", "cover.jpg", "image/jpeg")]
+    [InlineData("song", "cover.webp", "image/webp")]
+    [InlineData("song", "cover.avif", "image/avif")]
+    [InlineData("album", "cover.png", "image/png")]
+    [InlineData("album", "cover.jpg", "image/jpeg")]
+    [InlineData("album", "cover.webp", "image/webp")]
+    [InlineData("album", "cover.avif", "image/avif")]
+    [InlineData("artist", "cover.png", "image/png")]
+    [InlineData("artist", "cover.jpg", "image/jpeg")]
+    [InlineData("artist", "cover.webp", "image/webp")]
+    [InlineData("artist", "cover.avif", "image/avif")]
+    public async Task GetCover_SupportsMultipleFormats(string entityType, string coverFileName, string expectedContentType)
+    {
+        await using var app = AppTestContext.Create();
+        app.MusicLibrary.CreateTestMp3File("Artist/Album/song.mp3", title: "Song", artist: "Artist", album: "Album");
+        var coverData = GetCoverData(coverFileName);
+        app.MusicLibrary.AddFile($"Artist/Album/{coverFileName}", coverData);
+
+        var library = await app.ScanCatalog();
+        var id = entityType switch
+        {
+            "song" => library.GetAllSongs().Single().Id,
+            "album" => library.GetAllAlbums().Single().Id,
+            "artist" => library.GetAllArtists().Single().Id,
+            _ => throw new InvalidOperationException($"Unsupported entity type: {entityType}"),
+        };
+
+        var endpoint = entityType switch
+        {
+            "song" => $"/api/songs/{id}/cover",
+            "album" => $"/api/albums/{id}/cover",
+            "artist" => $"/api/artists/{id}/cover",
+            _ => throw new InvalidOperationException($"Unsupported entity type: {entityType}"),
+        };
+
+        using var response = await app.Client.GetAsync(endpoint, app.CancellationToken);
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expectedContentType, response.Content.Headers.ContentType?.MediaType);
+        var returnedCoverData = await response.Content.ReadAsByteArrayAsync(app.CancellationToken);
+        Assert.Equal(coverData, returnedCoverData);
+    }
+
+    private static byte[] GetCoverData(string coverFileName)
+    {
+        return Path.GetExtension(coverFileName).ToLowerInvariant() switch
+        {
+            ".png" =>
+            [
+                0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+                0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+                0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            ],
+            ".jpg" or ".jpeg" =>
+            [
+                0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46,
+                0x49, 0x46, 0x00, 0x01, 0xFF, 0xD9,
+            ],
+            ".webp" =>
+            [
+                0x52, 0x49, 0x46, 0x46, 0x18, 0x00, 0x00, 0x00,
+                0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x20,
+                0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ],
+            ".avif" =>
+            [
+                0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+                0x61, 0x76, 0x69, 0x66, 0x00, 0x00, 0x00, 0x00,
+                0x61, 0x76, 0x69, 0x66, 0x6D, 0x69, 0x66, 0x31,
+            ],
+            _ => throw new InvalidOperationException($"Unsupported cover extension for test: {coverFileName}"),
+        };
+    }
 }

--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -360,7 +360,7 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
 
         ImageCacheHelper.SetImageCacheHeaders(Response, coverArtData.LastModified);
 
-        return File(coverData, "image/jpeg");
+        return File(coverData, ImageCacheHelper.GetImageContentType(coverData));
     }
 
     /// <summary>Get cover image for an album (uses first track)</summary>
@@ -400,7 +400,7 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
 
         ImageCacheHelper.SetImageCacheHeaders(Response, coverArtData.LastModified);
 
-        return File(coverData, "image/jpeg");
+        return File(coverData, ImageCacheHelper.GetImageContentType(coverData));
     }
 
     /// <summary>Get cover image for an artist (uses first track)</summary>
@@ -452,7 +452,7 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
 
         ImageCacheHelper.SetImageCacheHeaders(Response, coverArtData.LastModified);
 
-        return File(coverData, "image/jpeg");
+        return File(coverData, ImageCacheHelper.GetImageContentType(coverData));
     }
 
     /// <summary>Get all albums</summary>

--- a/Meziantou.MusicApp.Server/Services/ImageCacheHelper.cs
+++ b/Meziantou.MusicApp.Server/Services/ImageCacheHelper.cs
@@ -3,6 +3,23 @@ namespace Meziantou.MusicApp.Server.Services;
 /// <summary>Helper class providing common functionality for serving cached images</summary>
 public static class ImageCacheHelper
 {
+    public static string GetImageContentType(ReadOnlySpan<byte> imageData)
+    {
+        if (IsPng(imageData))
+            return "image/png";
+
+        if (IsJpeg(imageData))
+            return "image/jpeg";
+
+        if (IsWebP(imageData))
+            return "image/webp";
+
+        if (IsAvif(imageData))
+            return "image/avif";
+
+        return "image/jpeg";
+    }
+
     /// <summary>Sets HTTP cache headers for image responses based on file modification time</summary>
     /// <param name="response">The HTTP response object</param>
     /// <param name="lastModified">The last modified date of the image file</param>
@@ -41,5 +58,59 @@ public static class ImageCacheHelper
             clientDate.Offset);
         
         return serverTime <= clientTime;
+    }
+
+    private static bool IsPng(ReadOnlySpan<byte> data)
+    {
+        return data.Length >= 8 &&
+               data[0] == 0x89 &&
+               data[1] == 0x50 &&
+               data[2] == 0x4E &&
+               data[3] == 0x47 &&
+               data[4] == 0x0D &&
+               data[5] == 0x0A &&
+               data[6] == 0x1A &&
+               data[7] == 0x0A;
+    }
+
+    private static bool IsJpeg(ReadOnlySpan<byte> data)
+    {
+        return data.Length >= 3 &&
+               data[0] == 0xFF &&
+               data[1] == 0xD8 &&
+               data[2] == 0xFF;
+    }
+
+    private static bool IsWebP(ReadOnlySpan<byte> data)
+    {
+        return data.Length >= 12 &&
+               data[0] == (byte)'R' &&
+               data[1] == (byte)'I' &&
+               data[2] == (byte)'F' &&
+               data[3] == (byte)'F' &&
+               data[8] == (byte)'W' &&
+               data[9] == (byte)'E' &&
+               data[10] == (byte)'B' &&
+               data[11] == (byte)'P';
+    }
+
+    private static bool IsAvif(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 16)
+            return false;
+
+        if (data[4] != (byte)'f' || data[5] != (byte)'t' || data[6] != (byte)'y' || data[7] != (byte)'p')
+            return false;
+
+        for (var i = 8; i <= data.Length - 4; i += 4)
+        {
+            if ((data[i] == (byte)'a' && data[i + 1] == (byte)'v' && data[i + 2] == (byte)'i' && data[i + 3] == (byte)'f') ||
+                (data[i] == (byte)'a' && data[i + 1] == (byte)'v' && data[i + 2] == (byte)'i' && data[i + 3] == (byte)'s'))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -36,14 +36,16 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     private static readonly string[] XspfPlaylistExtensions = [".xspf"];
     private static readonly string[] CoverFiles =
     [
-        "cover.jpg", "cover.jpeg", "cover.png",
-        "folder.jpg", "folder.jpeg", "folder.png",
-        "front.jpg", "front.jpeg", "front.png",
-        "album.jpg", "album.jpeg", "album.png",
-        "Cover.jpg", "Cover.jpeg", "Cover.png",
-        "Folder.jpg", "Folder.jpeg", "Folder.png",
-        "Front.jpg", "Front.jpeg", "Front.png",
-        "Album.jpg", "Album.jpeg", "Album.png",
+        "cover.avif", "folder.avif", "front.avif", "album.avif",
+        "Cover.avif", "Folder.avif", "Front.avif", "Album.avif",
+        "cover.webp", "folder.webp", "front.webp", "album.webp",
+        "Cover.webp", "Folder.webp", "Front.webp", "Album.webp",
+        "cover.png", "folder.png", "front.png", "album.png",
+        "Cover.png", "Folder.png", "Front.png", "Album.png",
+        "cover.jpg", "folder.jpg", "front.jpg", "album.jpg",
+        "Cover.jpg", "Folder.jpg", "Front.jpg", "Album.jpg",
+        "cover.jpeg", "folder.jpeg", "front.jpeg", "album.jpeg",
+        "Cover.jpeg", "Folder.jpeg", "Front.jpeg", "Album.jpeg",
     ];
 
     public MusicCatalog Catalog => _catalog;

--- a/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
@@ -91,7 +91,7 @@ export function CoverImage({
         const api = getApiService();
         const coverUrl = api.getSongCoverUrl(trackId, size);
         
-        const response = await fetch(coverUrl, { headers: api.getAuthHeaders() });
+        const response = await fetch(coverUrl, { headers: api.getCoverHeaders() });
         if (!response.ok) {
           if (response.status === 404) {
             storageService.addMissingCover(trackId).catch(console.error);

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { ApiService } from './api-service';
+
+describe('ApiService', () => {
+  it('getCoverHeaders prefers modern image formats', () => {
+    const service = new ApiService('https://example.com', 'test-token');
+
+    expect(service.getCoverHeaders()).toEqual({
+      Authorization: 'Bearer test-token',
+      Accept: 'image/avif,image/webp,image/png,image/jpeg;q=0.8,*/*;q=0.5'
+    });
+  });
+});

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
@@ -9,6 +9,8 @@ import type {
 } from '../types';
 
 export class ApiService {
+  private static readonly coverAcceptHeader = 'image/avif,image/webp,image/png,image/jpeg;q=0.8,*/*;q=0.5';
+
   private baseUrl: string;
   private authToken: string;
 
@@ -148,6 +150,13 @@ export class ApiService {
   getAuthHeaders(): HeadersInit {
     return {
       'Authorization': `Bearer ${this.authToken}`
+    };
+  }
+
+  getCoverHeaders(): HeadersInit {
+    return {
+      ...this.getAuthHeaders(),
+      'Accept': ApiService.coverAcceptHeader
     };
   }
 

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -286,12 +286,12 @@ export class AudioPlayerService {
       artist: this.currentTrack.artists ?? 'Unknown Artist',
       album: this.currentTrack.album ?? 'Unknown Album',
       artwork: [
-        { src: api.getSongCoverUrl(this.currentTrack.id, 96), sizes: '96x96', type: 'image/jpeg' },
-        { src: api.getSongCoverUrl(this.currentTrack.id, 128), sizes: '128x128', type: 'image/jpeg' },
-        { src: api.getSongCoverUrl(this.currentTrack.id, 192), sizes: '192x192', type: 'image/jpeg' },
-        { src: api.getSongCoverUrl(this.currentTrack.id, 256), sizes: '256x256', type: 'image/jpeg' },
-        { src: api.getSongCoverUrl(this.currentTrack.id, 384), sizes: '384x384', type: 'image/jpeg' },
-        { src: api.getSongCoverUrl(this.currentTrack.id, 512), sizes: '512x512', type: 'image/jpeg' }
+        { src: api.getSongCoverUrl(this.currentTrack.id, 96), sizes: '96x96' },
+        { src: api.getSongCoverUrl(this.currentTrack.id, 128), sizes: '128x128' },
+        { src: api.getSongCoverUrl(this.currentTrack.id, 192), sizes: '192x192' },
+        { src: api.getSongCoverUrl(this.currentTrack.id, 256), sizes: '256x256' },
+        { src: api.getSongCoverUrl(this.currentTrack.id, 384), sizes: '384x384' },
+        { src: api.getSongCoverUrl(this.currentTrack.id, 512), sizes: '512x512' }
       ]
     });
 

--- a/Meziantou.MusicApp.WebPlayer/src/services/download-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/download-service.ts
@@ -167,7 +167,7 @@ class DownloadService {
           // Use a reasonable size for caching (256px)
           const coverUrl = api.getSongCoverUrl(track.id, 256);
           const coverResponse = await fetch(coverUrl, {
-            headers: api.getAuthHeaders()
+            headers: api.getCoverHeaders()
           });
           
           if (coverResponse.ok) {


### PR DESCRIPTION
The cover endpoints and Web Player were effectively JPEG-oriented, which prevented correct handling of modern cover formats and did not ensure clients requested the most efficient image type.

This change adds end-to-end multi-format cover support and format preference behavior:

- Extend cover discovery to include AVIF and WebP (with preferred ordering when multiple cover files exist).
- Add signature-based image MIME detection for PNG, JPEG, WebP, and AVIF.
- Update REST cover endpoints (`/api/songs/{id}/cover`, `/api/albums/{id}/cover`, `/api/artists/{id}/cover`) to return the detected image MIME type instead of a fixed `image/jpeg`.
- Update Web Player cover fetches to send a preferred-image `Accept` header (`avif -> webp -> png -> jpeg`) and remove JPEG-only assumptions from Media Session artwork metadata.
- Add server integration tests covering song/album/artist cover responses for png/jpg/webp/avif.
- Add Web Player unit test validating cover request header preferences.

### Validation

- `dotnet test --nologo`
- `cd Meziantou.MusicApp.WebPlayer && npm install && npm test`