### PR TITLE
Make server and web player fully read-only

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
@@ -8,12 +8,28 @@ namespace Meziantou.MusicApp.Server.Tests.Integration;
 public class RestApiIntegrationTests
 {
     [Fact]
-    public async Task TriggerScanRoute_IsNotAvailable()
+    public async Task TriggerScan_WithValidAuth_ReturnsOk()
     {
+        // Act
         await using var app = AppTestContext.Create();
         using var response = await app.Client.PostAsync("/api/scan.json", content: null, app.CancellationToken);
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        InlineSnapshot
+            .WithSerializer(serializer => serializer.ScrubJsonValue("$.isScanning", node => "[redacted]"))
+            .Validate(response, """
+                StatusCode: 200 (OK)
+                Headers:
+                  Cache-Control: no-store, must-revalidate, no-cache
+                Content:
+                  Headers:
+                    Content-Type: application/json; charset=utf-8
+                  Value:
+                    {
+                      "isScanning": "[redacted]",
+                      "isInitialScanCompleted": true,
+                      "scanCount": 0,
+                      "invalidPlaylists": []
+                    }
+                """);
     }
 
     [Fact]

--- a/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Http.Json;
 using Meziantou.MusicApp.Server.Tests.Helpers;
 using Meziantou.Framework.InlineSnapshotTesting;
 
@@ -6,28 +8,21 @@ namespace Meziantou.MusicApp.Server.Tests.Integration;
 public class RestApiIntegrationTests
 {
     [Fact]
-    public async Task TriggerScan_WithValidAuth_ReturnsOk()
+    public async Task TriggerScanRoute_IsNotAvailable()
     {
-        // Act
         await using var app = AppTestContext.Create();
         using var response = await app.Client.PostAsync("/api/scan.json", content: null, app.CancellationToken);
-        InlineSnapshot
-            .WithSerializer(serializer => serializer.ScrubJsonValue("$.isScanning", node => "[redacted]"))
-            .Validate(response, """
-                StatusCode: 200 (OK)
-                Headers:
-                  Cache-Control: no-store, must-revalidate, no-cache
-                Content:
-                  Headers:
-                    Content-Type: application/json; charset=utf-8
-                  Value:
-                    {
-                      "isScanning": "[redacted]",
-                      "isInitialScanCompleted": true,
-                      "scanCount": 0,
-                      "invalidPlaylists": []
-                    }
-                """);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ScrobbleRoute_IsNotAvailable()
+    {
+        await using var app = AppTestContext.Create();
+        using var response = await app.Client.PostAsJsonAsync("/api/scrobble.json", new { id = "song-1", submission = true }, app.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]

--- a/Meziantou.MusicApp.Server.Tests/Integration/SubsonicApiIntegrationTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Integration/SubsonicApiIntegrationTests.cs
@@ -46,7 +46,7 @@ public class SubsonicApiIntegrationTests
     }
 
     [Fact]
-    public async Task Ping_WithInvalidToken_ReturnsAuthError()
+    public async Task Ping_WithInvalidToken_IsAccepted()
     {
         // Arrange
         await using var app = AppTestContext.Create();
@@ -65,11 +65,8 @@ public class SubsonicApiIntegrationTests
               Cache-Control: no-store, must-revalidate, no-cache
             Content:
               Headers:
-                Content-Type: application/xml
-              Value:
-                <subsonic-response status="failed" version="1.16.1" xmlns="http://subsonic.org/restapi">
-                  <error code="40" message="Wrong username or password" />
-                </subsonic-response>
+                Content-Type: application/xml; charset=utf-8
+              Value: <subsonic-response status="ok" version="1.16.1" xmlns="http://subsonic.org/restapi" />
             """);
     }
 
@@ -400,13 +397,12 @@ public class SubsonicApiIntegrationTests
     }
 
     [Fact]
-    public async Task CreatePlaylist_ReturnsPlaylistId()
+    public async Task CreatePlaylist_ReturnsReadOnlyError()
     {
         // Arrange
         await using var app = AppTestContext.Create();
         app.SetAuthToken(AuthToken);
-        var playlistName = "Test Playlist " + Guid.NewGuid();
-        var url = BuildAuthenticatedUrl($"/rest/createPlaylist.view?name={Uri.EscapeDataString(playlistName)}");
+        var url = BuildAuthenticatedUrl("/rest/createPlaylist.view?name=Test");
 
         // Act
         using var response = await app.Client.GetAsync(url, app.CancellationToken);
@@ -417,12 +413,8 @@ public class SubsonicApiIntegrationTests
         var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
         var xml = XDocument.Parse(content);
 
-        Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
-
-        var playlist = xml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"));
-        Assert.NotNull(playlist);
-        Assert.NotNull(playlist.Attribute("id")?.Value);
-        Assert.Equal(playlistName, playlist.Attribute("name")?.Value);
+        Assert.Equal("failed", xml.Root?.Attribute("status")?.Value);
+        Assert.Equal("50", xml.Root?.Element(XName.Get("error", "http://subsonic.org/restapi"))?.Attribute("code")?.Value);
     }
 
     [Fact]
@@ -558,7 +550,7 @@ public class SubsonicApiIntegrationTests
     }
 
     [Fact]
-    public async Task Scrobble_WithValidAuth_ReturnsSuccess()
+    public async Task ScrobbleRoute_IsNotAvailable()
     {
         // Arrange
         await using var app = AppTestContext.Create();
@@ -569,12 +561,7 @@ public class SubsonicApiIntegrationTests
         using var response = await app.Client.GetAsync(url, app.CancellationToken);
 
         // Assert
-        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
-        var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
-        var xml = XDocument.Parse(content);
-
-        Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
@@ -858,280 +845,42 @@ public class SubsonicApiIntegrationTests
     }
 
     [Fact]
-    public async Task CreatePlaylist_WithValidName_CreatesPlaylist()
+    public async Task UpdatePlaylist_ReturnsReadOnlyError()
     {
-        // Arrange
         await using var app = AppTestContext.Create();
         app.SetAuthToken(AuthToken);
-        var playlistName = $"Test Playlist {Guid.NewGuid()}";
-        var url = BuildAuthenticatedUrl($"/rest/createPlaylist.view?name={Uri.EscapeDataString(playlistName)}");
-
-        // Act
-        using var response = await app.Client.GetAsync(url, app.CancellationToken);
-
-        // Assert
-        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
-        var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
-        var xml = XDocument.Parse(content);
-
-        Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
-
-        var playlistElement = xml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"));
-        Assert.NotNull(playlistElement);
-        Assert.Equal(playlistName, playlistElement.Attribute("name")?.Value);
-        Assert.Equal("0", playlistElement.Attribute("songCount")?.Value);
-    }
-
-    [Fact]
-    public async Task CreatePlaylist_WithSongs_CreatesPlaylistWithSongs()
-    {
-        // Arrange
-        await using var app = AppTestContext.Create();
-        app.SetAuthToken(AuthToken);
-
-        // Get some songs first
-        var searchUrl = BuildAuthenticatedUrl("/rest/search3.view?query=test&songCount=3");
-        using var searchResponse = await app.Client.GetAsync(searchUrl, app.CancellationToken);
-        var searchContent = await searchResponse.Content.ReadAsStringAsync(app.CancellationToken);
-        var searchXml = XDocument.Parse(searchContent);
-
-        var songs = searchXml.Descendants(XName.Get("song", "http://subsonic.org/restapi")).Take(3).ToList();
-
-        if (songs.Count > 0)
-        {
-            var playlistName = $"Test Playlist {Guid.NewGuid()}";
-            var songIdsParam = string.Join('&', songs.Select(s => $"songId={s.Attribute("id")?.Value}"));
-            using var response = await app.Client.GetAsync(BuildAuthenticatedUrl($"/rest/createPlaylist.view?name={Uri.EscapeDataString(playlistName)}&{songIdsParam}"), app.CancellationToken);
-
-            // Assert
-            Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
-            var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
-            var xml = XDocument.Parse(content);
-
-            Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
-
-            var playlistElement = xml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"));
-            Assert.NotNull(playlistElement);
-            Assert.Equal(playlistName, playlistElement.Attribute("name")?.Value);
-            Assert.Equal(songs.Count.ToString(CultureInfo.InvariantCulture), playlistElement.Attribute("songCount")?.Value);
-        }
-    }
-
-    [Fact]
-    public async Task UpdatePlaylist_WithNewName_UpdatesPlaylistName()
-    {
-        // Arrange
-        await using var app = AppTestContext.Create();
-        app.SetAuthToken(AuthToken);
-
-        // Create a playlist first
-        var originalName = $"Original Playlist {Guid.NewGuid()}";
-        var createUrl = BuildAuthenticatedUrl($"/rest/createPlaylist.view?name={Uri.EscapeDataString(originalName)}");
-        using var createResponse = await app.Client.GetAsync(createUrl, app.CancellationToken);
-        var createContent = await createResponse.Content.ReadAsStringAsync(app.CancellationToken);
-        var createXml = XDocument.Parse(createContent);
-
-        var playlistId = createXml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"))?.Attribute("id")?.Value;
-
-        if (!string.IsNullOrEmpty(playlistId))
-        {
-            // Update the playlist name
-            var newName = $"Updated Playlist {Guid.NewGuid()}";
-            var updateUrl = BuildAuthenticatedUrl($"/rest/updatePlaylist.view?playlistId={Uri.EscapeDataString(playlistId)}&name={Uri.EscapeDataString(newName)}");
-
-            // Act
-            using var response = await app.Client.GetAsync(updateUrl, app.CancellationToken);
-
-            // Assert
-            Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
-            var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
-            var xml = XDocument.Parse(content);
-
-            Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
-
-            // Verify the update by fetching all playlists
-            var playlistsUrl = BuildAuthenticatedUrl("/rest/getPlaylists.view");
-            using var playlistsResponse = await app.Client.GetAsync(playlistsUrl, app.CancellationToken);
-            var playlistsContent = await playlistsResponse.Content.ReadAsStringAsync(app.CancellationToken);
-            var playlistsXml = XDocument.Parse(playlistsContent);
-
-            var playlists = playlistsXml.Root?
-                .Element(XName.Get("playlists", "http://subsonic.org/restapi"))?
-                .Elements(XName.Get("playlist", "http://subsonic.org/restapi"));
-
-            // Verify the original name no longer exists
-            var originalPlaylist = playlists?.FirstOrDefault(p => p.Attribute("name")?.Value == originalName);
-            Assert.Null(originalPlaylist);
-
-            // Verify the new name exists
-            var updatedPlaylist = playlists?.FirstOrDefault(p => p.Attribute("name")?.Value == newName);
-            Assert.NotNull(updatedPlaylist);
-        }
-    }
-
-    [Fact]
-    public async Task UpdatePlaylist_AddingSongs_AddsItemsToPlaylist()
-    {
-        // Arrange
-        await using var app = AppTestContext.Create();
-        app.SetAuthToken(AuthToken);
-
-        // Create an empty playlist
-        var playlistName = $"Test Playlist {Guid.NewGuid()}";
-        var createUrl = BuildAuthenticatedUrl($"/rest/createPlaylist.view?name={Uri.EscapeDataString(playlistName)}");
-        using var createResponse = await app.Client.GetAsync(createUrl, app.CancellationToken);
-        var createContent = await createResponse.Content.ReadAsStringAsync(app.CancellationToken);
-        var createXml = XDocument.Parse(createContent);
-
-        var playlistId = createXml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"))?.Attribute("id")?.Value;
-
-        if (!string.IsNullOrEmpty(playlistId))
-        {
-            // Get some songs
-            var searchUrl = BuildAuthenticatedUrl("/rest/search3.view?query=test&songCount=2");
-            using var searchResponse = await app.Client.GetAsync(searchUrl, app.CancellationToken);
-            var searchContent = await searchResponse.Content.ReadAsStringAsync(app.CancellationToken);
-            var searchXml = XDocument.Parse(searchContent);
-
-            var songs = searchXml.Descendants(XName.Get("song", "http://subsonic.org/restapi")).Take(2).ToList();
-
-            if (songs.Count > 0)
-            {
-                var songIdsParam = string.Join('&', songs.Select(s => $"songIdToAdd={s.Attribute("id")?.Value}"));
-                using var response = await app.Client.GetAsync(BuildAuthenticatedUrl($"/rest/updatePlaylist.view?playlistId={Uri.EscapeDataString(playlistId)}&{songIdsParam}"), app.CancellationToken);
-
-                // Assert
-                Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
-                var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
-                var xml = XDocument.Parse(content);
-
-                Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
-
-                // Verify the songs were added
-                var getUrl = BuildAuthenticatedUrl($"/rest/getPlaylist.view?id={Uri.EscapeDataString(playlistId)}");
-                using var getResponse = await app.Client.GetAsync(getUrl, app.CancellationToken);
-                var getContent = await getResponse.Content.ReadAsStringAsync(app.CancellationToken);
-                var getXml = XDocument.Parse(getContent);
-
-                var updatedPlaylistElement = getXml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"));
-                Assert.NotNull(updatedPlaylistElement);
-                Assert.Equal(songs.Count.ToString(CultureInfo.InvariantCulture), updatedPlaylistElement.Attribute("songCount")?.Value);
-            }
-        }
-    }
-
-    [Fact]
-    public async Task UpdatePlaylist_RemovingSongs_RemovesItemsFromPlaylist()
-    {
-        // Arrange
-        await using var app = AppTestContext.Create();
-        app.SetAuthToken(AuthToken);
-
-        // Get some songs
-        var searchUrl = BuildAuthenticatedUrl("/rest/search3.view?query=test&songCount=3");
-        using var searchResponse = await app.Client.GetAsync(searchUrl, app.CancellationToken);
-        var searchContent = await searchResponse.Content.ReadAsStringAsync(app.CancellationToken);
-        var searchXml = XDocument.Parse(searchContent);
-
-        var songs = searchXml.Descendants(XName.Get("song", "http://subsonic.org/restapi")).Take(3).ToList();
-
-        if (songs.Count >= 2)
-        {
-            var playlistName = $"Test Playlist {Guid.NewGuid()}";
-            var songIdsParam = string.Join('&', songs.Select(s => $"songId={s.Attribute("id")?.Value}"));
-            using var createResponse = await app.Client.GetAsync(BuildAuthenticatedUrl($"/rest/createPlaylist.view?name={Uri.EscapeDataString(playlistName)}&{songIdsParam}"), app.CancellationToken);
-            var createContent = await createResponse.Content.ReadAsStringAsync(app.CancellationToken);
-            var createXml = XDocument.Parse(createContent);
-
-            var playlistId = createXml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"))?.Attribute("id")?.Value;
-
-            if (!string.IsNullOrEmpty(playlistId))
-            {
-                using var response = await app.Client.GetAsync(BuildAuthenticatedUrl($"/rest/updatePlaylist.view?playlistId={Uri.EscapeDataString(playlistId)}&songIndexToRemove=0"), app.CancellationToken);
-
-                // Assert
-                Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
-                var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
-                var xml = XDocument.Parse(content);
-
-                Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
-
-                // Verify the song was removed
-                var getUrl = BuildAuthenticatedUrl($"/rest/getPlaylist.view?id={Uri.EscapeDataString(playlistId)}");
-                using var getResponse = await app.Client.GetAsync(getUrl, app.CancellationToken);
-                var getContent = await getResponse.Content.ReadAsStringAsync(app.CancellationToken);
-                var getXml = XDocument.Parse(getContent);
-
-                var updatedPlaylistElement = getXml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"));
-                Assert.NotNull(updatedPlaylistElement);
-                var expectedCount = songs.Count - 1;
-                Assert.Equal(expectedCount.ToString(CultureInfo.InvariantCulture), updatedPlaylistElement.Attribute("songCount")?.Value);
-            }
-        }
-    }
-
-    [Fact]
-    public async Task DeletePlaylist_WithValidId_DeletesPlaylist()
-    {
-        // Arrange
-        await using var app = AppTestContext.Create();
-        app.SetAuthToken(AuthToken);
-
-        // Create a playlist first
-        var playlistName = $"Test Playlist {Guid.NewGuid()}";
-        var createUrl = BuildAuthenticatedUrl($"/rest/createPlaylist.view?name={Uri.EscapeDataString(playlistName)}");
-        using var createResponse = await app.Client.GetAsync(createUrl, app.CancellationToken);
-        var createContent = await createResponse.Content.ReadAsStringAsync(app.CancellationToken);
-        var createXml = XDocument.Parse(createContent);
-
-        var playlistId = createXml.Root?.Element(XName.Get("playlist", "http://subsonic.org/restapi"))?.Attribute("id")?.Value;
-
-        if (!string.IsNullOrEmpty(playlistId))
-        {
-            // Act
-            using var response = await app.Client.GetAsync(BuildAuthenticatedUrl($"/rest/deletePlaylist.view?id={Uri.EscapeDataString(playlistId)}"), app.CancellationToken);
-
-            // Assert
-            Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
-            var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
-            var xml = XDocument.Parse(content);
-
-            Assert.Equal("ok", xml.Root?.Attribute("status")?.Value);
-
-            // Verify the playlist no longer exists
-            var getUrl = BuildAuthenticatedUrl($"/rest/getPlaylist.view?id={Uri.EscapeDataString(playlistId)}");
-            using var getResponse = await app.Client.GetAsync(getUrl, app.CancellationToken);
-            var getContent = await getResponse.Content.ReadAsStringAsync(app.CancellationToken);
-            var getXml = XDocument.Parse(getContent);
-
-            Assert.Equal("failed", getXml.Root?.Attribute("status")?.Value);
-        }
-    }
-
-    [Fact]
-    public async Task DeletePlaylist_WithInvalidId_ReturnsError()
-    {
-        // Arrange
-        await using var app = AppTestContext.Create();
-        app.SetAuthToken(AuthToken);
-        var url = BuildAuthenticatedUrl("/rest/deletePlaylist.view?id=invalid-playlist-id");
-
-        // Act
-        using var response = await app.Client.GetAsync(url, app.CancellationToken);
-
-        // Assert
-        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
-
+        using var response = await app.Client.GetAsync(BuildAuthenticatedUrl("/rest/updatePlaylist.view?playlistId=test"), app.CancellationToken);
         var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
         var xml = XDocument.Parse(content);
 
         Assert.Equal("failed", xml.Root?.Attribute("status")?.Value);
+        Assert.Equal("50", xml.Root?.Element(XName.Get("error", "http://subsonic.org/restapi"))?.Attribute("code")?.Value);
+    }
+
+    [Fact]
+    public async Task DeletePlaylist_ReturnsReadOnlyError()
+    {
+        await using var app = AppTestContext.Create();
+        app.SetAuthToken(AuthToken);
+        using var response = await app.Client.GetAsync(BuildAuthenticatedUrl("/rest/deletePlaylist.view?id=test"), app.CancellationToken);
+        var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
+        var xml = XDocument.Parse(content);
+
+        Assert.Equal("failed", xml.Root?.Attribute("status")?.Value);
+        Assert.Equal("50", xml.Root?.Element(XName.Get("error", "http://subsonic.org/restapi"))?.Attribute("code")?.Value);
+    }
+
+    [Fact]
+    public async Task StartScan_ReturnsReadOnlyError()
+    {
+        await using var app = AppTestContext.Create();
+        app.SetAuthToken(AuthToken);
+        using var response = await app.Client.GetAsync(BuildAuthenticatedUrl("/rest/startScan.view"), app.CancellationToken);
+        var content = await response.Content.ReadAsStringAsync(app.CancellationToken);
+        var xml = XDocument.Parse(content);
+
+        Assert.Equal("failed", xml.Root?.Attribute("status")?.Value);
+        Assert.Equal("50", xml.Root?.Element(XName.Get("error", "http://subsonic.org/restapi"))?.Attribute("code")?.Value);
     }
 
     [Fact]

--- a/Meziantou.MusicApp.Server/Controllers/JellyfinController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/JellyfinController.cs
@@ -12,7 +12,6 @@ namespace Meziantou.MusicApp.Server.Controllers;
 public class JellyfinController : ControllerBase
 {
     private readonly MusicLibraryService _libraryService;
-    private readonly MusicServerSettings _commonSettings;
     private readonly JellyfinSettings _jellyfinSettings;
     private readonly TranscodingService _transcodingService;
     private readonly ImageResizingService _imageResizingService;
@@ -20,14 +19,12 @@ public class JellyfinController : ControllerBase
 
     public JellyfinController(
         MusicLibraryService libraryService,
-        IOptions<MusicServerSettings> commonSettings,
         IOptions<JellyfinSettings> jellyfinSettings,
         TranscodingService transcodingService,
         ImageResizingService imageResizingService,
         ILogger<JellyfinController> logger)
     {
         _libraryService = libraryService;
-        _commonSettings = commonSettings.Value;
         _jellyfinSettings = jellyfinSettings.Value;
         _transcodingService = transcodingService;
         _imageResizingService = imageResizingService;
@@ -71,18 +68,13 @@ public class JellyfinController : ControllerBase
     {
         _logger.LogInformation("Authentication attempt for user: {Username}", request.Username);
 
-        if (!string.IsNullOrEmpty(_commonSettings.AuthToken) && request.Pw != _commonSettings.AuthToken)
-        {
-            return Unauthorized(new { error = "Invalid username or password" });
-        }
-
         var user = new UserDto
         {
             Name = string.IsNullOrEmpty(request.Username) ? _jellyfinSettings.DefaultUserName : request.Username,
             ServerId = _jellyfinSettings.ServerId,
             Id = _jellyfinSettings.DefaultUserId,
-            HasPassword = !string.IsNullOrEmpty(_commonSettings.AuthToken),
-            HasConfiguredPassword = !string.IsNullOrEmpty(_commonSettings.AuthToken),
+            HasPassword = false,
+            HasConfiguredPassword = false,
             Policy = new UserPolicy
             {
                 IsAdministrator = true,
@@ -95,7 +87,7 @@ public class JellyfinController : ControllerBase
         return Ok(new AuthenticationResult
         {
             User = user,
-            AccessToken = _commonSettings.AuthToken,
+            AccessToken = request.Pw ?? string.Empty,
             ServerId = _jellyfinSettings.ServerId,
         });
     }
@@ -112,8 +104,8 @@ public class JellyfinController : ControllerBase
             Name = _jellyfinSettings.DefaultUserName,
             ServerId = _jellyfinSettings.ServerId,
             Id = userId,
-            HasPassword = !string.IsNullOrEmpty(_commonSettings.AuthToken),
-            HasConfiguredPassword = !string.IsNullOrEmpty(_commonSettings.AuthToken),
+            HasPassword = false,
+            HasConfiguredPassword = false,
             Policy = new UserPolicy
             {
                 IsAdministrator = true,

--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -8,7 +8,7 @@ namespace Meziantou.MusicApp.Server.Controllers;
 [ApiController]
 [Route("api")]
 [ExcludeFromDescription]
-public class RestApiController(MusicLibraryService library, TranscodingService transcoding, ImageResizingService imageResizing, LastFmService lastFm, ILogger<RestApiController> logger) : ControllerBase
+public class RestApiController(MusicLibraryService library, TranscodingService transcoding, ImageResizingService imageResizing, ILogger<RestApiController> logger) : ControllerBase
 {
     /// <summary>Get all playlists with name and track count</summary>
     [HttpGet("playlists.json")]
@@ -45,148 +45,6 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
         }
 
         return Ok(CreatePlaylistTracksResponse(playlist));
-    }
-
-    /// <summary>Create a new playlist</summary>
-    [HttpPost("playlists.json")]
-    [ProducesResponseType<PlaylistTracksResponse>(StatusCodes.Status201Created)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<PlaylistTracksResponse>> CreatePlaylist([FromBody] CreatePlaylistRequest request)
-    {
-        try
-        {
-            var playlist = await library.CreatePlaylist(request.Name, request.Comment, request.SongIds);
-            var response = CreatePlaylistTracksResponse(playlist);
-            return CreatedAtAction(nameof(GetPlaylistTracks), new { id = playlist.Id }, response);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to create playlist");
-            return BadRequest(new ErrorResponse { Error = "Failed to create playlist" });
-        }
-    }
-
-    /// <summary>Update an existing playlist</summary>
-    [HttpPut("playlists/{id}.json")]
-    [ProducesResponseType<PlaylistTracksResponse>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<PlaylistTracksResponse>> UpdatePlaylist(string id, [FromBody] UpdatePlaylistRequest request)
-    {
-        try
-        {
-            var playlist = await library.UpdatePlaylist(id, request.Name, request.Comment, request.SongIds);
-            return Ok(CreatePlaylistTracksResponse(playlist));
-        }
-        catch (FileNotFoundException)
-        {
-            return NotFound(new ErrorResponse { Error = "Playlist not found" });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to update playlist");
-            return BadRequest(new ErrorResponse { Error = "Failed to update playlist" });
-        }
-    }
-
-    /// <summary>Delete a playlist</summary>
-    [HttpDelete("playlists/{id}.json")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeletePlaylist(string id)
-    {
-        try
-        {
-            await library.DeletePlaylist(id);
-            return NoContent();
-        }
-        catch (FileNotFoundException)
-        {
-            return NotFound(new ErrorResponse { Error = "Playlist not found" });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to delete playlist");
-            return BadRequest(new ErrorResponse { Error = "Failed to delete playlist" });
-        }
-    }
-
-    /// <summary>Rename a playlist (renames the file on disk)</summary>
-    [HttpPost("playlists/{id}/rename.json")]
-    [ProducesResponseType<PlaylistTracksResponse>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status409Conflict)]
-    public async Task<ActionResult<PlaylistTracksResponse>> RenamePlaylist(string id, [FromBody] RenamePlaylistRequest request)
-    {
-        try
-        {
-            var playlist = await library.RenamePlaylist(id, request.Name);
-            return Ok(CreatePlaylistTracksResponse(playlist));
-        }
-        catch (FileNotFoundException)
-        {
-            return NotFound(new ErrorResponse { Error = "Playlist not found" });
-        }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("already exists", StringComparison.Ordinal))
-        {
-            return Conflict(new ErrorResponse { Error = ex.Message });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to rename playlist");
-            return BadRequest(new ErrorResponse { Error = "Failed to rename playlist" });
-        }
-    }
-
-    /// <summary>Add a track to a playlist</summary>
-    [HttpPost("playlists/{id}/tracks.json")]
-    [ProducesResponseType<PlaylistTracksResponse>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<PlaylistTracksResponse>> AddTrackToPlaylist(string id, [FromBody] AddTrackToPlaylistRequest request)
-    {
-        try
-        {
-            var playlist = await library.AddTrackToPlaylist(id, request.SongId);
-            return Ok(CreatePlaylistTracksResponse(playlist));
-        }
-        catch (FileNotFoundException)
-        {
-            return NotFound(new ErrorResponse { Error = "Playlist or song not found" });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to add track to playlist");
-            return BadRequest(new ErrorResponse { Error = "Failed to add track to playlist" });
-        }
-    }
-
-    /// <summary>Remove a track from a playlist</summary>
-    [HttpDelete("playlists/{id}/tracks/{trackIndex}.json")]
-    [ProducesResponseType<PlaylistTracksResponse>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<PlaylistTracksResponse>> RemoveTrackFromPlaylist(string id, int trackIndex)
-    {
-        try
-        {
-            var playlist = await library.RemoveTrackFromPlaylist(id, trackIndex);
-            return Ok(CreatePlaylistTracksResponse(playlist));
-        }
-        catch (FileNotFoundException)
-        {
-            return NotFound(new ErrorResponse { Error = "Playlist not found" });
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            return BadRequest(new ErrorResponse { Error = "Track index is out of range" });
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to remove track from playlist");
-            return BadRequest(new ErrorResponse { Error = "Failed to remove track from playlist" });
-        }
     }
 
     private PlaylistTracksResponse CreatePlaylistTracksResponse(Playlist playlist)
@@ -491,25 +349,6 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
         return Ok(new ArtistsResponse { Artists = artists });
     }
 
-    /// <summary>Trigger a library scan</summary>
-    [HttpPost("scan.json")]
-    [ProducesResponseType<ScanStatusResponse>(StatusCodes.Status200OK)]
-    public ActionResult<ScanStatusResponse> TriggerScan()
-    {
-        // Trigger scan in background
-        _ = Task.Run(() => library.ScanMusicLibrary());
-
-        return Ok(new ScanStatusResponse
-        {
-            IsScanning = library.IsScanning,
-            IsInitialScanCompleted = library.IsInitialScanCompleted,
-            ScanCount = library.ScanCount,
-            LastScanDate = library.LastScanDate,
-            Percentage = library.ScanProgress,
-            EstimatedCompletionTime = library.ScanEta,
-        });
-    }
-
     /// <summary>Get scan status</summary>
     [HttpGet("scan/status.json")]
     [ProducesResponseType<ScanStatusResponse>(StatusCodes.Status200OK)]
@@ -549,50 +388,4 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
         return Ok(new LyricsResponse { Lyrics = normalizedLyrics });
     }
 
-    /// <summary>Scrobble a track to Last.fm</summary>
-    /// <remarks>
-    /// Sends track play information to Last.fm.
-    /// When submission is true, it records the track as played.
-    /// When submission is false, it updates the "Now Playing" status.
-    /// </remarks>
-    [HttpPost("scrobble.json")]
-    [ProducesResponseType<ScrobbleResponse>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status404NotFound)]
-    [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<ScrobbleResponse>> Scrobble([FromBody] ScrobbleRequest request)
-    {
-        if (string.IsNullOrEmpty(request.Id))
-        {
-            return BadRequest(new ErrorResponse { Error = "Song ID is required" });
-        }
-
-        var song = library.GetSong(request.Id);
-        if (song == null)
-        {
-            return NotFound(new ErrorResponse { Error = "Song not found" });
-        }
-
-        if (!lastFm.IsConfigured)
-        {
-            return Ok(new ScrobbleResponse
-            {
-                Success = false,
-                Title = song.Title,
-                Artist = song.Artist,
-                Message = "Last.fm is not configured",
-            });
-        }
-
-        var success = await lastFm.ScrobbleAsync(song, request.Submission, HttpContext.RequestAborted);
-
-        return Ok(new ScrobbleResponse
-        {
-            Success = success,
-            Title = song.Title,
-            Artist = song.Artist,
-            Message = success
-                ? (request.Submission ? "Track scrobbled successfully" : "Now Playing updated successfully")
-                : "Failed to scrobble to Last.fm",
-        });
-    }
 }

--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -349,6 +349,25 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
         return Ok(new ArtistsResponse { Artists = artists });
     }
 
+    /// <summary>Trigger a library scan</summary>
+    [HttpPost("scan.json")]
+    [ProducesResponseType<ScanStatusResponse>(StatusCodes.Status200OK)]
+    public ActionResult<ScanStatusResponse> TriggerScan()
+    {
+        // Trigger scan in background
+        _ = Task.Run(() => library.ScanMusicLibrary());
+
+        return Ok(new ScanStatusResponse
+        {
+            IsScanning = library.IsScanning,
+            IsInitialScanCompleted = library.IsInitialScanCompleted,
+            ScanCount = library.ScanCount,
+            LastScanDate = library.LastScanDate,
+            Percentage = library.ScanProgress,
+            EstimatedCompletionTime = library.ScanEta,
+        });
+    }
+
     /// <summary>Get scan status</summary>
     [HttpGet("scan/status.json")]
     [ProducesResponseType<ScanStatusResponse>(StatusCodes.Status200OK)]

--- a/Meziantou.MusicApp.Server/Controllers/SubsonicController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/SubsonicController.cs
@@ -16,7 +16,6 @@ public class SubsonicController : ControllerBase
     private readonly MusicServerSettings _commonSettings;
     private readonly TranscodingService _transcodingService;
     private readonly ImageResizingService _imageResizingService;
-    private readonly LastFmService _lastFmService;
     private readonly ILogger<SubsonicController> _logger;
     private static readonly XNamespace SubsonicNamespace = "http://subsonic.org/restapi";
 
@@ -25,14 +24,12 @@ public class SubsonicController : ControllerBase
         IOptions<MusicServerSettings> commonSettings,
         TranscodingService transcodingService,
         ImageResizingService imageResizingService,
-        LastFmService lastFmService,
         ILogger<SubsonicController> logger)
     {
         _libraryService = libraryService;
         _commonSettings = commonSettings.Value;
         _transcodingService = transcodingService;
         _imageResizingService = imageResizingService;
-        _lastFmService = lastFmService;
         _logger = logger;
     }
 
@@ -582,19 +579,6 @@ public class SubsonicController : ControllerBase
         return Ok(response);
     }
 
-    [HttpGet("startScan.view")]
-    public IActionResult StartScan()
-    {
-        _ = Task.Run(async () => await _libraryService.ScanMusicLibrary());
-
-        var response = CreateResponse();
-        response.Root!.Add(new XElement(SubsonicNamespace + "scanStatus",
-            new XAttribute("scanning", "true"),
-            new XAttribute("count", 0)
-        ));
-        return Ok(response);
-    }
-
     [HttpGet("getIndexes.view")]
     public IActionResult GetIndexes([FromQuery] string? musicFolderId)
     {
@@ -697,18 +681,6 @@ public class SubsonicController : ControllerBase
         return Ok(response);
     }
 
-    [HttpGet("scrobble.view")]
-    public async Task<IActionResult> Scrobble([FromQuery] string id, [FromQuery] bool? submission)
-    {
-        var song = _libraryService.GetSong(id);
-        if (song is not null)
-        {
-            await _lastFmService.ScrobbleAsync(song, submission ?? true, HttpContext.RequestAborted);
-        }
-
-        return Ok(CreateResponse());
-    }
-
     [HttpGet("getStarred2.view")]
     public IActionResult GetStarred2()
     {
@@ -743,143 +715,10 @@ public class SubsonicController : ControllerBase
         return Ok(response);
     }
 
+    [HttpGet("startScan.view")]
     [HttpGet("createPlaylist.view")]
-    public async Task<IActionResult> CreatePlaylist(
-        [FromQuery] string? name,
-        [FromQuery] string? playlistId,
-        [FromQuery] string? comment,
-        [FromQuery] string[]? songId)
-    {
-        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(playlistId))
-        {
-            return Ok(CreateError(10, "Required parameter is missing: name or playlistId"));
-        }
-
-        try
-        {
-            var playlistName = name ?? "New Playlist";
-            var songIds = songId?.ToList() ?? new List<string>();
-
-            var playlist = await _libraryService.CreatePlaylist(playlistName, comment, songIds);
-
-            var response = CreateResponse();
-            var playlistElement = new XElement(SubsonicNamespace + "playlist",
-                new XAttribute("id", playlist.Id),
-                new XAttribute("name", playlist.Name),
-                new XAttribute("songCount", playlist.SongCount),
-                new XAttribute("duration", playlist.Duration),
-                new XAttribute("created", playlist.Created.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)),
-                new XAttribute("changed", playlist.Changed.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)),
-                new XAttribute("owner", "admin"),
-                new XAttribute("public", "false")
-            );
-
-            if (playlist.CoverArt is not null)
-                playlistElement.Add(new XAttribute("coverArt", playlist.CoverArt.Id));
-            if (!string.IsNullOrEmpty(playlist.Comment))
-                playlistElement.Add(new XAttribute("comment", playlist.Comment));
-
-            response.Root!.Add(playlistElement);
-            return Ok(response);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to create playlist");
-            return Ok(CreateError(0, "Failed to create playlist"));
-        }
-    }
-
     [HttpGet("updatePlaylist.view")]
-    public async Task<IActionResult> UpdatePlaylist(
-        [FromQuery] string? playlistId,
-        [FromQuery] string? name,
-        [FromQuery] string? comment,
-        [FromQuery] string[]? songIdToAdd,
-        [FromQuery] int[]? songIndexToRemove)
-    {
-        if (string.IsNullOrEmpty(playlistId))
-        {
-            return Ok(CreateError(10, "Required parameter is missing: playlistId"));
-        }
-
-        try
-        {
-            var playlist = _libraryService.GetPlaylist(playlistId);
-            if (playlist is null)
-            {
-                return Ok(CreateError(70, "Playlist not found"));
-            }
-
-            // Build the updated song list
-            List<string>? updatedSongIds = null;
-
-            // If we need to modify the song list
-            if (songIdToAdd?.Length > 0 || songIndexToRemove?.Length > 0)
-            {
-                updatedSongIds = playlist.Items.Select(i => i.Song.Id).ToList();
-
-                // Remove songs by index (in reverse order to maintain indices)
-                if (songIndexToRemove?.Length > 0)
-                {
-                    foreach (var index in songIndexToRemove.OrderByDescending(i => i))
-                    {
-                        if (index >= 0 && index < updatedSongIds.Count)
-                        {
-                            updatedSongIds.RemoveAt(index);
-                        }
-                    }
-                }
-
-                // Add new songs
-                if (songIdToAdd?.Length > 0)
-                {
-                    updatedSongIds.AddRange(songIdToAdd);
-                }
-            }
-
-            var updatedPlaylist = await _libraryService.UpdatePlaylist(
-                playlistId,
-                name,
-                comment,
-                updatedSongIds);
-
-            return Ok(CreateResponse());
-        }
-        catch (FileNotFoundException)
-        {
-            return Ok(CreateError(70, "Playlist not found"));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to update playlist");
-            return Ok(CreateError(0, "Failed to update playlist"));
-        }
-    }
-
     [HttpGet("deletePlaylist.view")]
-    public async Task<IActionResult> DeletePlaylist([FromQuery] string? id)
-    {
-        if (string.IsNullOrEmpty(id))
-        {
-            return Ok(CreateError(10, "Required parameter is missing: id"));
-        }
-
-        try
-        {
-            await _libraryService.DeletePlaylist(id);
-            return Ok(CreateResponse());
-        }
-        catch (FileNotFoundException)
-        {
-            return Ok(CreateError(70, "Playlist not found"));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to delete playlist");
-            return Ok(CreateError(0, "Failed to delete playlist"));
-        }
-    }
-
     [HttpGet("star.view")]
     [HttpGet("unstar.view")]
     [HttpGet("setRating.view")]

--- a/Meziantou.MusicApp.Server/Middleware/JellyfinAuthMiddleware.cs
+++ b/Meziantou.MusicApp.Server/Middleware/JellyfinAuthMiddleware.cs
@@ -1,14 +1,8 @@
-using System.Text.Json;
-using Meziantou.MusicApp.Server.Models;
-using Microsoft.Extensions.Options;
-
 namespace Meziantou.MusicApp.Server.Middleware;
 
 [ExcludeFromDescription]
-public class JellyfinAuthMiddleware(RequestDelegate next, IOptions<MusicServerSettings> commonSettings, ILogger<JellyfinAuthMiddleware> logger)
+public class JellyfinAuthMiddleware(RequestDelegate next, ILogger<JellyfinAuthMiddleware> logger)
 {
-    private readonly MusicServerSettings _commonSettings = commonSettings.Value;
-
     public async Task InvokeAsync(HttpContext context)
     {
         // Skip auth for certain Jellyfin paths
@@ -31,74 +25,6 @@ public class JellyfinAuthMiddleware(RequestDelegate next, IOptions<MusicServerSe
 
         logger.LogInformation("Jellyfin request: {Method} {Path}", context.Request.Method, path);
 
-        // Check for authentication token
-        var authHeader = context.Request.Headers["X-Emby-Authorization"].FirstOrDefault()
-                      ?? context.Request.Headers["Authorization"].FirstOrDefault();
-
-        if (string.IsNullOrEmpty(_commonSettings.AuthToken))
-        {
-            // No authentication required
-            await next(context);
-            return;
-        }
-
-        if (string.IsNullOrEmpty(authHeader))
-        {
-            await WriteUnauthorized(context);
-            return;
-        }
-
-        // Parse Emby/Jellyfin auth header format:
-        // MediaBrowser Client="...", Device="...", DeviceId="...", Version="...", Token="..."
-        var authenticated = false;
-        
-        if (authHeader.StartsWith("MediaBrowser ", StringComparison.OrdinalIgnoreCase))
-        {
-            var token = ExtractTokenFromHeader(authHeader);
-            if (!string.IsNullOrEmpty(token))
-            {
-                authenticated = token == _commonSettings.AuthToken;
-            }
-        }
-        else if (authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-        {
-            var token = authHeader.Substring(7);
-            authenticated = token == _commonSettings.AuthToken;
-        }
-
-        if (!authenticated)
-        {
-            logger.LogWarning("Failed Jellyfin authentication");
-            await WriteUnauthorized(context);
-            return;
-        }
-
         await next(context);
-    }
-
-    private static string? ExtractTokenFromHeader(string header)
-    {
-        // Parse format: MediaBrowser Token="abc123", Client="...", ...
-        var tokenPrefix = "Token=\"";
-        var tokenIndex = header.IndexOf(tokenPrefix, StringComparison.OrdinalIgnoreCase);
-        if (tokenIndex < 0)
-            return null;
-
-        var startIndex = tokenIndex + tokenPrefix.Length;
-        var endIndex = header.IndexOf('"', startIndex);
-        if (endIndex < 0)
-            return null;
-
-        return header.Substring(startIndex, endIndex - startIndex);
-    }
-
-    private static async Task WriteUnauthorized(HttpContext context)
-    {
-        context.Response.StatusCode = 401;
-        context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync(JsonSerializer.Serialize(new
-        {
-            error = "Unauthorized",
-        }));
     }
 }

--- a/Meziantou.MusicApp.Server/Middleware/RestApiAuthMiddleware.cs
+++ b/Meziantou.MusicApp.Server/Middleware/RestApiAuthMiddleware.cs
@@ -1,13 +1,7 @@
-using System.Text.Json;
-using Meziantou.MusicApp.Server.Models;
-using Microsoft.Extensions.Options;
-
 namespace Meziantou.MusicApp.Server.Middleware;
 
-public class RestApiAuthMiddleware(RequestDelegate next, IOptions<MusicServerSettings> commonSettings, ILogger<RestApiAuthMiddleware> logger)
+public class RestApiAuthMiddleware(RequestDelegate next, ILogger<RestApiAuthMiddleware> logger)
 {
-    private readonly MusicServerSettings _commonSettings = commonSettings.Value;
-
     public async Task InvokeAsync(HttpContext context)
     {
         var path = context.Request.Path.Value ?? "";
@@ -21,47 +15,6 @@ public class RestApiAuthMiddleware(RequestDelegate next, IOptions<MusicServerSet
 
         logger.LogInformation("REST API request: {Method} {Path}", context.Request.Method, path);
 
-        // Check for authentication token
-        var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
-
-        if (string.IsNullOrEmpty(_commonSettings.AuthToken))
-        {
-            // No authentication required
-            await next(context);
-            return;
-        }
-
-        if (string.IsNullOrEmpty(authHeader))
-        {
-            await WriteUnauthorized(context);
-            return;
-        }
-
-        // Parse Bearer token
-        var authenticated = false;
-        if (authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-        {
-            var token = authHeader.Substring(7);
-            authenticated = token == _commonSettings.AuthToken;
-        }
-
-        if (!authenticated)
-        {
-            logger.LogWarning("Failed REST API authentication");
-            await WriteUnauthorized(context);
-            return;
-        }
-
         await next(context);
-    }
-
-    private static async Task WriteUnauthorized(HttpContext context)
-    {
-        context.Response.StatusCode = 401;
-        context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync(JsonSerializer.Serialize(new
-        {
-            error = "Unauthorized",
-        }));
     }
 }

--- a/Meziantou.MusicApp.Server/Middleware/SubsonicAuthMiddleware.cs
+++ b/Meziantou.MusicApp.Server/Middleware/SubsonicAuthMiddleware.cs
@@ -1,15 +1,11 @@
-using System.Security.Cryptography;
 using System.Xml.Linq;
-using Meziantou.MusicApp.Server.Models;
-using Microsoft.Extensions.Options;
 
 namespace Meziantou.MusicApp.Server.Middleware;
 
 [ExcludeFromDescription]
-public class SubsonicAuthMiddleware(RequestDelegate next, IOptions<MusicServerSettings> commonSettings, ILogger<SubsonicAuthMiddleware> logger)
+public class SubsonicAuthMiddleware(RequestDelegate next, ILogger<SubsonicAuthMiddleware> logger)
 {
     private const string SubsonicServerVersion = "1.16.1";
-    private readonly MusicServerSettings _commonSettings = commonSettings.Value;
 
     public async Task InvokeAsync(HttpContext context)
     {
@@ -23,9 +19,6 @@ public class SubsonicAuthMiddleware(RequestDelegate next, IOptions<MusicServerSe
         // Check for required parameters
         var query = context.Request.Query;
         var username = query["u"].FirstOrDefault();
-        var token = query["t"].FirstOrDefault();
-        var salt = query["s"].FirstOrDefault();
-        var password = query["p"].FirstOrDefault();
         var version = query["v"].FirstOrDefault();
         var client = query["c"].FirstOrDefault();
 
@@ -39,50 +32,7 @@ public class SubsonicAuthMiddleware(RequestDelegate next, IOptions<MusicServerSe
             return;
         }
 
-        // Simple authentication: either token+salt or password
-        var authenticated = false;
-
-        if (string.IsNullOrEmpty(_commonSettings.AuthToken))
-        {
-            // No authentication required
-            authenticated = true;
-        }
-        else if (!string.IsNullOrEmpty(token) && !string.IsNullOrEmpty(salt))
-        {
-            // Token-based auth (recommended)
-            var expectedToken = ComputeMD5(_commonSettings.AuthToken + salt);
-            authenticated = token.Equals(expectedToken, StringComparison.OrdinalIgnoreCase);
-        }
-        else if (!string.IsNullOrEmpty(password))
-        {
-            // Password-based auth (legacy)
-            if (password.StartsWith("enc:", StringComparison.Ordinal))
-            {
-                var hexPassword = password.Substring(4);
-                var decodedPassword = Encoding.UTF8.GetString(Convert.FromHexString(hexPassword));
-                authenticated = decodedPassword == _commonSettings.AuthToken;
-            }
-            else
-            {
-                authenticated = password == _commonSettings.AuthToken;
-            }
-        }
-
-        if (!authenticated)
-        {
-            logger.LogWarning("Failed Subsonic authentication for user: {Username}", username);
-            await WriteError(context, 40, "Wrong username or password");
-            return;
-        }
-
         await next(context);
-    }
-
-    [SuppressMessage("Security", "CA5351:Do Not Use Broken Cryptographic Algorithms")]
-    private static string ComputeMD5(string input)
-    {
-        var hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
-        return Convert.ToHexStringLower(hash);
     }
 
     private static async Task WriteError(HttpContext context, int code, string message)

--- a/Meziantou.MusicApp.Server/README.md
+++ b/Meziantou.MusicApp.Server/README.md
@@ -1,6 +1,6 @@
 # Meziantou MusicServer
 
-This project is a music streaming server that supports both Subsonic and Jellyfin APIs. It allows you to stream your music collection over the network, with features like on-the-fly transcoding, Last.fm scrobbling, and ReplayGain support.
+This project is a music streaming server that supports both Subsonic and Jellyfin APIs. It allows you to stream your music collection over the network, with features like on-the-fly transcoding and ReplayGain support.
 
 ## Features
 
@@ -9,10 +9,9 @@ This project is a music streaming server that supports both Subsonic and Jellyfi
 - ID3 tag reading using Meziantou.Framework.MediaTags
 - Lyrics support from file metadata
 - Cover art extraction from files or folders
-- Simple token-based authentication
-- Single-user mode (hardcoded token)
+- Read-only API surface (no server-side write actions)
+- Token values are accepted without validation
 - Audio transcoding with FFmpeg support
-- Last.fm Scrobbling: Send play data to Last.fm
 - ReplayGain Support: Read and compute ReplayGain for volume normalization
 
 ## Running the Application
@@ -92,26 +91,7 @@ Enable automatic ReplayGain computation in `appsettings.json`:
 - `ComputeMissingReplayGain`: When `true`, tracks without ReplayGain tags will be analyzed during library scans (default: `false`)
 - `MaxConcurrentReplayGainAnalysis`: Maximum number of concurrent FFmpeg analysis processes (default: `2`)
 
-## Last.fm Scrobbling
-
-The server supports scrobbling (sending track play data) to Last.fm. This allows you to track your listening history on Last.fm.
-
-### Configuration
-
-Add your Last.fm credentials to `appsettings.json`:
-
-```json
-{
-  "LastFm": {
-    "ApiKey": "your-api-key",
-    "ApiSecret": "your-api-secret",
-    "SessionKey": "your-session-key"
-  }
-}
-```
-
 ## References
 
 - [Subsonic API Documentation](https://subsonic.org/pages/api.jsp)
 - [Jellyfin API Documentation](https://api.jellyfin.org/)
-- [Last.fm API Documentation](https://www.last.fm/api/)

--- a/Meziantou.MusicApp.Server/README.md
+++ b/Meziantou.MusicApp.Server/README.md
@@ -9,7 +9,7 @@ This project is a music streaming server that supports both Subsonic and Jellyfi
 - ID3 tag reading using Meziantou.Framework.MediaTags
 - Lyrics support from file metadata
 - Cover art extraction from files or folders
-- Read-only API surface (no server-side write actions)
+- Read-only API surface (except manual library rescan endpoint)
 - Token values are accepted without validation
 - Audio transcoding with FFmpeg support
 - ReplayGain Support: Read and compute ReplayGain for volume normalization

--- a/Meziantou.MusicApp.WebPlayer/README.md
+++ b/Meziantou.MusicApp.WebPlayer/README.md
@@ -5,7 +5,6 @@ This project is a web-based music player that connects to a compatible server an
 The features
 
 - Playlist Management: Browse and play playlists with thousands of tracks
-- Drag and drop: Drag a track onto a playlist to add it (online only)
 - PWA Support: Install as a native app on mobile and desktop
 - Offline Mode: Full offline support with automatic caching
 - Quality Control: Different streaming quality for Normal/Low Data connections
@@ -15,7 +14,7 @@ The features
 - AirPlay: Stream audio to AirPlay devices on Safari/macOS
 - Media Session API: System-level media controls and notifications
 - Dark Theme: Easy on the eyes
-- Scrobbler Support
+- Read-only server interaction (no playlist/server mutations)
 - State persistence: Playback state saved in IndexedDB
 - Auto-resume: Continues playback on app reopen
 - Background sync: Periodic playlist refresh (5 min intervals)
@@ -23,7 +22,7 @@ The features
 
 Configuration
 - Server URL: The URL of your Meziantou Music Server
-- Auth Token (optional): Your REST API authentication token
+- Authentication token is not required
 - Normal Data Quality: Streaming format and bitrate when on WiFi/Ethernet
 - Low Data Quality: Lower bitrate for cellular/slow networks
 - Download Quality: Quality for offline cached tracks
@@ -57,15 +56,13 @@ In the future, I want to support more backend servers like Subsonic, Airsonic, s
 - Playlist metadata: name, track count, duration
 - When a playlist is selected, its tracks are displayed in the main area
 - When a music is playint an indicator
-- Drop a track onto a playlist to add it (online only)
 
 # Track list
 - List of tracks with cover, title, artist, album, duration
 - Double-click on a track to play it
-- Drag a track onto a playlist in the sidebar to add it
 - Support playlists with thousands of tracks (performance optimized)
 - Search to filter tracks by title, artist, album (accent insensitive, case insensitive, partial matches, etc.)
-- Context menu on tracks for actions (download, add to playlist, remove from playlist, etc.)
+- Context menu on tracks for actions (download, queue, details, etc.)
 - Show indicator when a track is currently playing (the same track can be in multiple playlists, show the indicator only when the track is playing from that playlist)
 
 # Player bar

--- a/Meziantou.MusicApp.WebPlayer/README.md
+++ b/Meziantou.MusicApp.WebPlayer/README.md
@@ -14,7 +14,7 @@ The features
 - AirPlay: Stream audio to AirPlay devices on Safari/macOS
 - Media Session API: System-level media controls and notifications
 - Dark Theme: Easy on the eyes
-- Read-only server interaction (no playlist/server mutations)
+- Read-only server interaction (except manual library rescan)
 - State persistence: Playback state saved in IndexedDB
 - Auto-resume: Continues playback on app reopen
 - Background sync: Periodic playlist refresh (5 min intervals)

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlaylistSidebar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlaylistSidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo } from 'react';
 import type { PlaylistSummary } from '../types';
 import { formatDuration } from '../utils';
 import { useApp } from '../hooks';
@@ -13,69 +13,14 @@ export function PlaylistSidebar({ onSettingsClick }: PlaylistSidebarProps) {
     currentPlaylistId,
     playingPlaylistId,
     selectPlaylist,
-    addTrackToPlaylist,
     offlinePlaylistIds,
     playlistDownloadProgress,
     startPlaylistCaching,
     stopPlaylistCaching,
     isOnline,
     networkType,
-    createPlaylist,
-    deletePlaylist,
     invalidPlaylists,
   } = useApp();
-
-  const [isCreating, setIsCreating] = useState(false);
-  const [newPlaylistName, setNewPlaylistName] = useState('');
-
-  const handleCreateClick = useCallback(() => {
-    setIsCreating(true);
-    setNewPlaylistName('');
-  }, []);
-
-  const handleCancelCreate = useCallback(() => {
-    setIsCreating(false);
-    setNewPlaylistName('');
-  }, []);
-
-  const handleConfirmCreate = useCallback(async () => {
-    if (!newPlaylistName.trim()) return;
-
-    const playlist = await createPlaylist(newPlaylistName);
-    if (playlist) {
-      setIsCreating(false);
-      setNewPlaylistName('');
-      selectPlaylist(playlist);
-    }
-  }, [newPlaylistName, createPlaylist, selectPlaylist]);
-
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleConfirmCreate();
-    } else if (e.key === 'Escape') {
-      handleCancelCreate();
-    }
-  }, [handleConfirmCreate, handleCancelCreate]);
-
-  const handleDragOver = (e: React.DragEvent, _playlist: PlaylistSummary) => {
-    const hasTrackId = e.dataTransfer.types.includes('application/x-meziantou-song-id') ||
-      e.dataTransfer.types.includes('text/plain');
-    if (!hasTrackId) return;
-
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-  };
-
-  const handleDrop = (e: React.DragEvent, playlist: PlaylistSummary) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const trackId = e.dataTransfer.getData('application/x-meziantou-song-id') ||
-      e.dataTransfer.getData('text/plain');
-    if (!trackId) return;
-
-    addTrackToPlaylist(playlist, trackId);
-  };
 
   return (
     <aside className="sidebar">
@@ -83,53 +28,7 @@ export function PlaylistSidebar({ onSettingsClick }: PlaylistSidebarProps) {
       <div className="sidebar-section">
         <div className="sidebar-section-header">
           <h2 className="sidebar-section-title">Playlists</h2>
-          {isOnline && !isCreating && (
-            <button
-              className="new-playlist-btn"
-              onClick={handleCreateClick}
-              title="Create new playlist"
-            >
-              <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18">
-                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-              </svg>
-            </button>
-          )}
         </div>
-
-        {isCreating && (
-          <div className="new-playlist-form">
-            <input
-              type="text"
-              className="new-playlist-input"
-              placeholder="Playlist name"
-              value={newPlaylistName}
-              onChange={(e) => setNewPlaylistName(e.target.value)}
-              onKeyDown={handleKeyDown}
-              autoFocus
-            />
-            <div className="new-playlist-actions">
-              <button
-                className="new-playlist-confirm"
-                onClick={handleConfirmCreate}
-                disabled={!newPlaylistName.trim()}
-                title="Create"
-              >
-                <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
-                  <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
-                </svg>
-              </button>
-              <button
-                className="new-playlist-cancel"
-                onClick={handleCancelCreate}
-                title="Cancel"
-              >
-                <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
-                  <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        )}
 
         <div className="playlist-list">
           {playlists.length === 0 ? (
@@ -149,11 +48,8 @@ export function PlaylistSidebar({ onSettingsClick }: PlaylistSidebarProps) {
                   progress={progress}
                   isOnline={isOnline}
                   onSelect={() => selectPlaylist(playlist)}
-                  onDragOver={(e) => handleDragOver(e, playlist)}
-                  onDrop={(e) => handleDrop(e, playlist)}
                   onStartCaching={() => startPlaylistCaching(playlist.id)}
                   onStopCaching={() => stopPlaylistCaching(playlist.id)}
-                  onDelete={() => deletePlaylist(playlist.id)}
                 />
               );
             })
@@ -224,11 +120,8 @@ interface PlaylistItemProps {
   progress?: { cached: number; total: number };
   isOnline: boolean;
   onSelect: () => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDrop: (e: React.DragEvent) => void;
   onStartCaching: () => void;
   onStopCaching: () => void;
-  onDelete: () => void;
 }
 
 function PlaylistItem({
@@ -239,40 +132,17 @@ function PlaylistItem({
   progress,
   isOnline,
   onSelect,
-  onDragOver,
-  onDrop,
   onStartCaching,
   onStopCaching,
-  onDelete,
 }: PlaylistItemProps) {
-  const [isDragOver, setIsDragOver] = useState(false);
   const duration = useMemo(() => formatDuration(playlist.duration), [playlist.duration]);
-
-  const isVirtual = playlist.id.startsWith('virtual:');
 
   const className = [
     'playlist-item',
     isSelected && 'selected',
     isPlaying && 'playing',
     isOffline && 'offline',
-    isDragOver && 'drag-over',
   ].filter(Boolean).join(' ');
-
-  const handleDragOver = (e: React.DragEvent) => {
-    onDragOver(e);
-    if (e.dataTransfer.dropEffect !== 'none') {
-      setIsDragOver(true);
-    }
-  };
-
-  const handleDragLeave = () => {
-    setIsDragOver(false);
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    setIsDragOver(false);
-    onDrop(e);
-  };
 
   const handleDownloadClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -283,11 +153,6 @@ function PlaylistItem({
     }
   };
 
-  const handleDeleteClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onDelete();
-  };
-
   const isFullyCached = progress && progress.cached >= progress.total;
   const isCaching = isOffline && progress && progress.cached < progress.total;
 
@@ -295,9 +160,6 @@ function PlaylistItem({
     <div
       className={className}
       onClick={onSelect}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
@@ -348,17 +210,6 @@ function PlaylistItem({
                 <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
               </svg>
             )}
-          </button>
-        )}
-        {isOnline && !isVirtual && (
-          <button
-            className="playlist-delete-btn"
-            onClick={handleDeleteClick}
-            title="Delete playlist"
-          >
-            <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
-              <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
-            </svg>
           </button>
         )}
       </div>

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -28,10 +28,11 @@ interface SettingsDialogProps {
 }
 
 export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsDialogProps) {
-  const { settings, updateSettings, testConnection } = useApp();
+  const { settings, updateSettings, testConnection, triggerLibraryScan } = useApp();
 
   const [formData, setFormData] = useState<AppSettings>(settings);
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [scanStatus, setScanStatus] = useState<'idle' | 'scanning'>('idle');
   const settingsRef = useRef(settings);
   const prevIsOpenRef = useRef(isOpen);
 
@@ -64,6 +65,15 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
     setConnectionStatus('testing');
     const success = await testConnection();
     setConnectionStatus(success ? 'success' : 'error');
+  };
+
+  const handleRescanLibrary = async () => {
+    setScanStatus('scanning');
+    try {
+      await triggerLibraryScan();
+    } finally {
+      setScanStatus('idle');
+    }
   };
 
   const handleSave = async () => {
@@ -247,6 +257,16 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
           {onOpenDiagnostics && (
             <section className="settings-section">
               <h3>Advanced</h3>
+              <div className="form-group">
+                <button
+                  className="secondary-button"
+                  onClick={handleRescanLibrary}
+                  disabled={scanStatus === 'scanning'}
+                  style={{ width: '100%', marginBottom: '8px' }}
+                >
+                  {scanStatus === 'scanning' ? 'Scanning...' : 'Rescan Music Library'}
+                </button>
+              </div>
               <div className="form-group">
                 <button
                   className="secondary-button"

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
-import type { AppSettings, StreamingQuality, ReplayGainMode, ScanStatusResponse } from '../types';
+import type { AppSettings, StreamingQuality, ReplayGainMode } from '../types';
 import { DEFAULT_SETTINGS } from '../constants';
 import { useApp } from '../hooks';
-import { getApiService } from '../services';
 
 const QUALITY_OPTIONS: { label: string; value: StreamingQuality }[] = [
   { label: 'Original (Raw)', value: { format: 'raw' } },
@@ -29,12 +28,10 @@ interface SettingsDialogProps {
 }
 
 export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsDialogProps) {
-  const { settings, updateSettings, testConnection, triggerLibraryScan } = useApp();
+  const { settings, updateSettings, testConnection } = useApp();
 
   const [formData, setFormData] = useState<AppSettings>(settings);
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
-  const [scanStatus, setScanStatus] = useState<'idle' | 'scanning'>('idle');
-  const [scanProgress, setScanProgress] = useState<ScanStatusResponse | null>(null);
   const settingsRef = useRef(settings);
   const prevIsOpenRef = useRef(isOpen);
 
@@ -55,36 +52,6 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
     settingsRef.current = settings;
   }, [isOpen, settings]);
 
-  // Poll scan status when dialog is open
-  useEffect(() => {
-    if (!isOpen || !settings.serverUrl) return;
-
-    const pollScanStatus = async () => {
-      try {
-        const api = getApiService();
-        const status = await api.getScanStatus();
-        setScanProgress(status);
-        
-        if (status.isScanning) {
-          setScanStatus('scanning');
-        } else if (scanStatus === 'scanning') {
-          // Scan just completed
-          setScanStatus('idle');
-        }
-      } catch (error) {
-        console.error('Failed to get scan status:', error);
-      }
-    };
-
-    // Initial poll
-    pollScanStatus();
-
-    // Poll every 2 seconds while dialog is open
-    const interval = setInterval(pollScanStatus, 2000);
-
-    return () => clearInterval(interval);
-  }, [isOpen, settings.serverUrl, scanStatus]);
-
   if (!isOpen) return null;
 
   const getQualityIndex = (quality: StreamingQuality): number => {
@@ -97,12 +64,6 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
     setConnectionStatus('testing');
     const success = await testConnection();
     setConnectionStatus(success ? 'success' : 'error');
-  };
-
-  const handleRescanLibrary = async () => {
-    setScanStatus('scanning');
-    await triggerLibraryScan();
-    // Don't reset to idle - let the polling detect when scan completes
   };
 
   const handleSave = async () => {
@@ -119,30 +80,6 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
   const handleQualityChange = (field: 'normalQuality' | 'lowDataQuality' | 'downloadQuality', index: number) => {
     const quality = QUALITY_OPTIONS[index]?.value ?? DEFAULT_SETTINGS[field];
     setFormData(prev => ({ ...prev, [field]: quality }));
-  };
-
-  const formatEta = (etaString: string | null): string => {
-    if (!etaString) return '';
-    
-    try {
-      // Parse TimeSpan format (e.g., "00:05:30.1234567")
-      const parts = etaString.split(':');
-      if (parts.length < 3) return '';
-      
-      const hours = parseInt(parts[0], 10);
-      const minutes = parseInt(parts[1], 10);
-      const seconds = Math.floor(parseFloat(parts[2]));
-      
-      if (hours > 0) {
-        return `${hours}h ${minutes}m`;
-      } else if (minutes > 0) {
-        return `${minutes}m ${seconds}s`;
-      } else {
-        return `${seconds}s`;
-      }
-    } catch {
-      return '';
-    }
   };
 
   return (
@@ -169,17 +106,6 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
                 placeholder="https://your-server.com"
                 value={formData.serverUrl}
                 onChange={(e) => handleInputChange('serverUrl', e.target.value)}
-              />
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="auth-token">Auth Token (optional)</label>
-              <input
-                type="password"
-                id="auth-token"
-                placeholder="Your API token (optional)"
-                value={formData.authToken}
-                onChange={(e) => handleInputChange('authToken', e.target.value)}
               />
             </div>
 
@@ -274,19 +200,6 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
           <section className="settings-section">
             <h3>Playback</h3>
 
-            <div className="form-group checkbox-group">
-              <label>
-                <input
-                  type="checkbox"
-                  id="scrobble-enabled"
-                  checked={formData.scrobbleEnabled}
-                  onChange={(e) => handleInputChange('scrobbleEnabled', e.target.checked)}
-                />
-                Enable Scrobble
-              </label>
-              <small>Submit played tracks to the server</small>
-            </div>
-
             <div className="form-group">
               <label htmlFor="replaygain-mode">ReplayGain Mode</label>
               <select
@@ -331,57 +244,20 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
             </div>
           </section>
 
-          <section className="settings-section">
-            <h3>Advanced</h3>
-            <div className="form-group">
-              <button 
-                className="secondary-button" 
-                onClick={handleRescanLibrary}
-                disabled={scanStatus === 'scanning'}
-                style={{ width: '100%', marginBottom: scanProgress?.isScanning ? '8px' : onOpenDiagnostics ? '8px' : '0' }}
-              >
-                {scanStatus === 'scanning' ? 'Scanning...' : 'Rescan Music Library'}
-              </button>
-              {scanProgress?.isScanning && (
-                <div style={{ marginBottom: onOpenDiagnostics ? '8px' : '0' }}>
-                  <small style={{ display: 'block', marginBottom: '4px' }}>
-                    {scanProgress.percentage != null 
-                      ? `Progress: ${Math.round(scanProgress.percentage)}%`
-                      : 'Scanning...'}
-                    {scanProgress.estimatedCompletionTime && 
-                      ` - ETA: ${formatEta(scanProgress.estimatedCompletionTime)}`}
-                  </small>
-                  {scanProgress.percentage != null && (
-                    <div style={{ 
-                      width: '100%', 
-                      height: '4px', 
-                      backgroundColor: 'var(--color-bg-secondary, #e0e0e0)', 
-                      borderRadius: '2px',
-                      overflow: 'hidden'
-                    }}>
-                      <div style={{ 
-                        width: `${Math.min(100, Math.max(0, scanProgress.percentage))}%`, 
-                        height: '100%', 
-                        backgroundColor: 'var(--color-primary, #1976d2)',
-                        transition: 'width 0.3s ease'
-                      }} />
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-            {onOpenDiagnostics && (
+          {onOpenDiagnostics && (
+            <section className="settings-section">
+              <h3>Advanced</h3>
               <div className="form-group">
-                <button 
-                  className="secondary-button" 
+                <button
+                  className="secondary-button"
                   onClick={onOpenDiagnostics}
                   style={{ width: '100%' }}
                 >
                   Cache Diagnostics
                 </button>
               </div>
-            )}
-          </section>
+            </section>
+          )}
         </div>
 
         <div className="dialog-footer">

--- a/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
@@ -39,7 +39,6 @@ export function TrackList() {
     playTrack,
     downloadTrack,
     deleteDownloadedTrack,
-    removeTrackFromPlaylist,
     playerActions,
     showToast,
   } = useApp();
@@ -224,12 +223,6 @@ export function TrackList() {
     setContextMenu({ x: e.clientX, y: e.clientY, track, index });
   };
 
-  const handleDragStart = (e: React.DragEvent, track: TrackInfo) => {
-    e.dataTransfer.effectAllowed = 'copy';
-    e.dataTransfer.setData('application/x-meziantou-song-id', track.id);
-    e.dataTransfer.setData('text/plain', track.id);
-  };
-
   const handleDownloadRawFile = useCallback(async (track: TrackInfo) => {
     try {
       const apiService = getApiService();
@@ -353,7 +346,6 @@ export function TrackList() {
                   settings={settings}
                   onDoubleClick={() => handleTrackDoubleClick(track, originalIndex)}
                   onContextMenu={(e) => handleContextMenu(e, track, originalIndex)}
-                  onDragStart={(e) => handleDragStart(e, track)}
                   onTogglePlay={() => {
                     if (isPlaying) {
                       playerActions.togglePlayPause();
@@ -396,14 +388,6 @@ export function TrackList() {
             deleteDownloadedTrack(contextMenu.track);
             setContextMenu(null);
           }}
-          onRemoveFromPlaylist={
-            currentPlaylistId && !currentPlaylistId.startsWith('virtual:')
-              ? () => {
-                  removeTrackFromPlaylist(currentPlaylistId, contextMenu.index);
-                  setContextMenu(null);
-                }
-              : undefined
-          }
           onCopyFilePath={() => {
             navigator.clipboard.writeText(contextMenu.track.path).then(() => {
               showToast(`Copied file path: ${contextMenu.track.path}`);
@@ -432,7 +416,6 @@ interface TrackItemProps {
   settings: AppSettings;
   onDoubleClick: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
-  onDragStart: (e: React.DragEvent) => void;
   onTogglePlay: () => void;
 }
 
@@ -446,7 +429,6 @@ function TrackItem({
   settings,
   onDoubleClick,
   onContextMenu,
-  onDragStart,
   onTogglePlay,
 }: TrackItemProps) {
   const className = [
@@ -482,10 +464,8 @@ function TrackItem({
   return (
     <div
       className={className}
-      draggable={isAvailable}
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}
-      onDragStart={onDragStart}
     >
       <div className="track-index-container">
         <span className="track-index">{index + 1}</span>

--- a/Meziantou.MusicApp.WebPlayer/src/constants.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/constants.ts
@@ -2,12 +2,10 @@ import type { AppSettings, PlaybackState } from './types';
 
 export const DEFAULT_SETTINGS: AppSettings = {
   serverUrl: '',
-  authToken: '',
   normalQuality: { format: 'opus', maxBitRate: 160 },
   lowDataQuality: { format: 'opus', maxBitRate: 160 },
   downloadQuality: { format: 'opus', maxBitRate: 160 },
   preventDownloadOnLowData: false,
-  scrobbleEnabled: true,
   hideCoverArt: false,
   replayGainMode: 'off',
   replayGainPreamp: 0,

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -141,7 +141,7 @@ export function AppProvider({ children }: AppProviderProps) {
         const loadedSettings = await storageService.getSettings(DEFAULT_SETTINGS);
         console.log('[useApp] Settings loaded:', loadedSettings);
         setSettings(loadedSettings);
-        initApiService(loadedSettings.serverUrl, loadedSettings.authToken);
+        initApiService(loadedSettings.serverUrl);
 
         // Apply loaded settings to audio player
         playerActions.setReplayGainMode(loadedSettings.replayGainMode);
@@ -661,18 +661,16 @@ export function AppProvider({ children }: AppProviderProps) {
 
   const updateSettings = useCallback(async (newSettings: AppSettings) => {
     console.log('[useApp] updateSettings called with:', newSettings);
-    const serverChanged = newSettings.serverUrl !== settings.serverUrl ||
-      newSettings.authToken !== settings.authToken;
+    const serverChanged = newSettings.serverUrl !== settings.serverUrl;
 
     setSettings(newSettings);
     console.log('[useApp] Calling storageService.saveSettings');
     await storageService.saveSettings(newSettings);
     console.log('[useApp] storageService.saveSettings completed');
-    initApiService(newSettings.serverUrl, newSettings.authToken);
+    initApiService(newSettings.serverUrl);
 
     playerActions.setReplayGainMode(newSettings.replayGainMode);
     playerActions.setReplayGainPreamp(newSettings.replayGainPreamp);
-    playerActions.setScrobbleEnabled(newSettings.scrobbleEnabled);
     playerActions.setPreventDownloadOnLowData(newSettings.preventDownloadOnLowData);
 
     const networkType = getNetworkType();
@@ -794,157 +792,18 @@ export function AppProvider({ children }: AppProviderProps) {
     showToast('All cached data cleared');
   }, [playerActions, showToast]);
 
-  const addTrackToPlaylist = useCallback(async (playlist: PlaylistSummary, trackId: string) => {
-    if (!isOnline) {
-      showToast('Cannot modify playlists while offline', 'error');
-      return;
-    }
+  const addTrackToPlaylist = useCallback(async (_playlist: PlaylistSummary, _trackId: string) => {
+    showToast('Server is read-only');
+  }, [showToast]);
 
-    if (!settings.serverUrl) {
-      showToast('Server is not configured', 'error');
-      return;
-    }
-
-    if (playlist.id.startsWith('virtual:')) {
-      showToast('Cannot add tracks to this playlist', 'error');
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      const api = getApiService();
-      const existing = await api.getPlaylistTracks(playlist.id);
-
-      const isAlreadyInPlaylist = existing.tracks.some(t => t.id === trackId);
-      if (isAlreadyInPlaylist) {
-        const shouldAddAgain = window.confirm('This track is already in this playlist. Add it again?');
-        if (!shouldAddAgain) {
-          return;
-        }
-      }
-
-      const updated = await api.addTrackToPlaylist(playlist.id, trackId);
-
-      setPlaylists(prev => prev.map(p =>
-        p.id === playlist.id
-          ? { ...p, name: updated.name, trackCount: updated.trackCount, duration: updated.duration, changed: updated.changed }
-          : p
-      ));
-
-      const updatedSummary = playlists.find(p => p.id === playlist.id);
-      if (updatedSummary) {
-        await storageService.saveCachedPlaylist(updatedSummary, updated.tracks);
-      }
-
-      if (currentPlaylistId === playlist.id) {
-        setCurrentPlaylistTracks(updated.tracks);
-      }
-
-      // If this playlist is marked for offline, refresh progress and download the new track
-      if (offlinePlaylistIds.has(playlist.id)) {
-        let cachedCount = 0;
-        for (const t of updated.tracks) {
-          if (cachedTrackIds.has(t.id)) cachedCount++;
-        }
-        const total = updated.tracks.length;
-        setPlaylistDownloadProgress(prev => {
-          const next = new Map(prev);
-          next.set(playlist.id, { cached: cachedCount, total });
-          return next;
-        });
-
-        // Download the new track if not already cached
-        if (!cachedTrackIds.has(trackId)) {
-          const newTrack = updated.tracks.find(t => t.id === trackId);
-          if (newTrack) {
-            await downloadService.queueDownload(newTrack, playlist.id, settings.downloadQuality);
-          }
-        }
-      }
-
-      showToast('Added track to playlist', 'success');
-    } catch (error) {
-      console.error('Failed to add track to playlist:', error);
-      showToast('Failed to add track to playlist', 'error');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isOnline, settings.serverUrl, settings.downloadQuality, playlists, currentPlaylistId, offlinePlaylistIds, cachedTrackIds, showToast]);
-
-  const removeTrackFromPlaylist = useCallback(async (playlistId: string, trackIndex: number) => {
-    if (!isOnline) {
-      showToast('Cannot modify playlists while offline', 'error');
-      return;
-    }
-
-    if (!settings.serverUrl) {
-      showToast('Server is not configured', 'error');
-      return;
-    }
-
-    if (playlistId.startsWith('virtual:')) {
-      showToast('Cannot remove tracks from this playlist', 'error');
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      const api = getApiService();
-
-      let tracks = currentPlaylistTracks;
-      if (currentPlaylistId !== playlistId) {
-         const response = await api.getPlaylistTracks(playlistId);
-         tracks = response.tracks;
-      }
-
-      if (trackIndex < 0 || trackIndex >= tracks.length) {
-          showToast('Invalid track index', 'error');
-          return;
-      }
-
-      const updated = await api.removeTrackFromPlaylist(playlistId, trackIndex);
-
-      setPlaylists(prev => prev.map(p =>
-        p.id === playlistId
-          ? { ...p, name: updated.name, trackCount: updated.trackCount, duration: updated.duration, changed: updated.changed }
-          : p
-      ));
-
-      const updatedSummary = playlists.find(p => p.id === playlistId);
-      if (updatedSummary) {
-        await storageService.saveCachedPlaylist(updatedSummary, updated.tracks);
-      }
-
-      if (currentPlaylistId === playlistId) {
-        setCurrentPlaylistTracks(updated.tracks);
-      }
-
-      if (offlinePlaylistIds.has(playlistId)) {
-        let cachedCount = 0;
-        for (const t of updated.tracks) {
-          if (cachedTrackIds.has(t.id)) cachedCount++;
-        }
-        const total = updated.tracks.length;
-        setPlaylistDownloadProgress(prev => {
-          const next = new Map(prev);
-          next.set(playlistId, { cached: cachedCount, total });
-          return next;
-        });
-      }
-
-      showToast('Removed track from playlist', 'success');
-    } catch (error) {
-      console.error('Failed to remove track from playlist:', error);
-      showToast('Failed to remove track from playlist', 'error');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isOnline, settings.serverUrl, currentPlaylistId, currentPlaylistTracks, playlists, offlinePlaylistIds, cachedTrackIds, showToast]);
+  const removeTrackFromPlaylist = useCallback(async (_playlistId: string, _trackIndex: number) => {
+    showToast('Server is read-only');
+  }, [showToast]);
 
   const testConnection = useCallback(async () => {
     try {
       const api = getApiService();
-      api.updateConfig(settings.serverUrl, settings.authToken);
+      api.updateConfig(settings.serverUrl);
       return await api.testConnection();
     } catch {
       return false;
@@ -952,170 +811,23 @@ export function AppProvider({ children }: AppProviderProps) {
   }, [settings]);
 
   const triggerLibraryScan = useCallback(async () => {
-    if (!isOnline) {
-      showToast('Cannot trigger scan while offline', 'error');
-      return;
-    }
-
-    if (!settings.serverUrl) {
-      showToast('Server is not configured', 'error');
-      return;
-    }
-
-    try {
-      const api = getApiService();
-      await api.triggerScan();
-      showToast('Library scan started', 'success');
-
-      // Check for invalid playlists after a short delay to allow scan to complete
-      setTimeout(async () => {
-        try {
-          const status = await api.getScanStatus();
-          if (status.invalidPlaylists) {
-            setInvalidPlaylists(status.invalidPlaylists);
-          }
-        } catch (error) {
-          console.error('Failed to check for invalid playlists:', error);
-        }
-      }, 3000);
-    } catch (error) {
-      console.error('Failed to trigger library scan:', error);
-      showToast('Failed to trigger library scan', 'error');
-    }
-  }, [isOnline, settings.serverUrl, showToast]);
+    showToast('Server is read-only');
+  }, [showToast]);
 
   const syncPlaylists = useCallback(async () => {
     await syncPlaylistsInternal();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOnline]);
 
-  const createPlaylist = useCallback(async (name: string): Promise<PlaylistSummary | null> => {
-    if (!isOnline) {
-      showToast('Cannot create playlists while offline', 'error');
-      return null;
-    }
+  const createPlaylist = useCallback(async (_name: string): Promise<PlaylistSummary | null> => {
+    showToast('Server is read-only');
+    return null;
+  }, [showToast]);
 
-    if (!settings.serverUrl) {
-      showToast('Server is not configured', 'error');
-      return null;
-    }
-
-    const trimmedName = name.trim();
-    if (!trimmedName) {
-      showToast('Playlist name is required', 'error');
-      return null;
-    }
-
-    setIsLoading(true);
-    try {
-      const api = getApiService();
-      const response = await api.createPlaylist({ name: trimmedName });
-
-      const newPlaylist: PlaylistSummary = {
-        id: response.id,
-        name: response.name,
-        trackCount: response.trackCount,
-        duration: response.duration,
-        created: response.created,
-        changed: response.changed,
-        sortOrder: playlists.length,
-      };
-
-      // Refetch playlists to get correct sort order from server
-      await syncPlaylistsInternal();
-
-      showToast(`Created playlist "${trimmedName}"`, 'success');
-      return newPlaylist;
-    } catch (error) {
-      console.error('Failed to create playlist:', error);
-      showToast('Failed to create playlist', 'error');
-      return null;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isOnline, settings.serverUrl, playlists.length, showToast]);
-
-  const deletePlaylist = useCallback(async (playlistId: string): Promise<boolean> => {
-    if (!isOnline) {
-      showToast('Cannot delete playlists while offline', 'error');
-      return false;
-    }
-
-    if (!settings.serverUrl) {
-      showToast('Server is not configured', 'error');
-      return false;
-    }
-
-    if (playlistId.startsWith('virtual:')) {
-      showToast('Cannot delete this playlist', 'error');
-      return false;
-    }
-
-    const playlist = playlists.find(p => p.id === playlistId);
-    if (!playlist) {
-      showToast('Playlist not found', 'error');
-      return false;
-    }
-
-    const confirmed = window.confirm(`Are you sure you want to delete "${playlist.name}"?`);
-    if (!confirmed) {
-      return false;
-    }
-
-    setIsLoading(true);
-    try {
-      const api = getApiService();
-      await api.deletePlaylist(playlistId);
-
-      // If this playlist was marked for offline, clean up
-      if (offlinePlaylistIds.has(playlistId)) {
-        downloadService.cancelPlaylistDownloads(playlistId);
-        await storageService.setPlaylistOffline(playlistId, false);
-        await downloadService.deletePlaylistTracks(playlistId);
-        setOfflinePlaylistIds(prev => {
-          const next = new Set(prev);
-          next.delete(playlistId);
-          return next;
-        });
-        setPlaylistDownloadProgress(prev => {
-          if (!prev.has(playlistId)) return prev;
-          const next = new Map(prev);
-          next.delete(playlistId);
-          return next;
-        });
-      }
-
-      // Remove from cached playlists
-      await storageService.deleteCachedPlaylist(playlistId);
-
-      // Cleanup orphaned tracks
-      await storageService.cleanupOrphanedTracks();
-
-      // Update local state
-      setPlaylists(prev => prev.filter(p => p.id !== playlistId));
-
-      // If this was the current playlist, clear selection
-      if (currentPlaylistId === playlistId) {
-        setCurrentPlaylistId(null);
-        setCurrentPlaylistTracks([]);
-      }
-
-      // If this was the playing playlist, stop playback
-      if (playingPlaylistId === playlistId) {
-        playerActions.pause();
-        setPlayingPlaylistId(null);
-      }
-
-      showToast(`Deleted playlist "${playlist.name}"`, 'success');
-      return true;
-    } catch (error) {
-      console.error('Failed to delete playlist:', error);
-      showToast('Failed to delete playlist', 'error');
-      return false;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isOnline, settings.serverUrl, playlists, currentPlaylistId, playingPlaylistId, offlinePlaylistIds, playerActions, showToast]);
+  const deletePlaylist = useCallback(async (_playlistId: string): Promise<boolean> => {
+    showToast('Server is read-only');
+    return false;
+  }, [showToast]);
 
   // Start caching a playlist for offline use
   const startPlaylistCaching = useCallback(async (playlistId: string) => {

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -811,8 +811,37 @@ export function AppProvider({ children }: AppProviderProps) {
   }, [settings]);
 
   const triggerLibraryScan = useCallback(async () => {
-    showToast('Server is read-only');
-  }, [showToast]);
+    if (!isOnline) {
+      showToast('Cannot trigger scan while offline', 'error');
+      return;
+    }
+
+    if (!settings.serverUrl) {
+      showToast('Server is not configured', 'error');
+      return;
+    }
+
+    try {
+      const api = getApiService();
+      await api.triggerScan();
+      showToast('Library scan started', 'success');
+
+      // Check for invalid playlists after a short delay to allow scan to complete
+      setTimeout(async () => {
+        try {
+          const status = await api.getScanStatus();
+          if (status.invalidPlaylists) {
+            setInvalidPlaylists(status.invalidPlaylists);
+          }
+        } catch (error) {
+          console.error('Failed to check for invalid playlists:', error);
+        }
+      }, 3000);
+    } catch (error) {
+      console.error('Failed to trigger library scan:', error);
+      showToast('Failed to trigger library scan', 'error');
+    }
+  }, [isOnline, settings.serverUrl, showToast]);
 
   const syncPlaylists = useCallback(async () => {
     await syncPlaylistsInternal();

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
@@ -3,10 +3,9 @@ import { ApiService } from './api-service';
 
 describe('ApiService', () => {
   it('getCoverHeaders prefers modern image formats', () => {
-    const service = new ApiService('https://example.com', 'test-token');
+    const service = new ApiService('https://example.com');
 
     expect(service.getCoverHeaders()).toEqual({
-      Authorization: 'Bearer test-token',
       Accept: 'image/avif,image/webp,image/png,image/jpeg;q=0.8,*/*;q=0.5'
     });
   });

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
@@ -54,6 +54,10 @@ export class ApiService {
     return this.fetch<ScanStatusResponse>('/api/scan/status.json');
   }
 
+  async triggerScan(): Promise<ScanStatusResponse> {
+    return this.fetch<ScanStatusResponse>('/api/scan.json', { method: 'POST' });
+  }
+
   getSongStreamUrl(songId: string, quality: StreamingQuality): string {
     const params = new URLSearchParams();
 

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
@@ -3,8 +3,6 @@ import type {
   PlaylistTracksResponse,
   ScanStatusResponse,
   StreamingQuality,
-  CreatePlaylistRequest,
-  UpdatePlaylistRequest,
   LyricsResponse
 } from '../types';
 
@@ -12,16 +10,13 @@ export class ApiService {
   private static readonly coverAcceptHeader = 'image/avif,image/webp,image/png,image/jpeg;q=0.8,*/*;q=0.5';
 
   private baseUrl: string;
-  private authToken: string;
 
-  constructor(baseUrl: string, authToken: string) {
+  constructor(baseUrl: string) {
     this.baseUrl = baseUrl.replace(/\/$/, '');
-    this.authToken = authToken;
   }
 
-  updateConfig(baseUrl: string, authToken: string): void {
+  updateConfig(baseUrl: string): void {
     this.baseUrl = baseUrl.replace(/\/$/, '');
-    this.authToken = authToken;
   }
 
   private async fetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
@@ -33,10 +28,7 @@ export class ApiService {
       const response = await fetch(url, {
         ...options,
         signal: controller.signal,
-        headers: {
-          'Authorization': `Bearer ${this.authToken}`,
-          ...options.headers
-        }
+        headers: options.headers
       });
 
       if (!response.ok) {
@@ -58,73 +50,8 @@ export class ApiService {
     return this.fetch<PlaylistTracksResponse>(`/api/playlists/${encodeURIComponent(playlistId)}.json`);
   }
 
-  async updatePlaylist(playlistId: string, request: UpdatePlaylistRequest): Promise<PlaylistTracksResponse> {
-    return this.fetch<PlaylistTracksResponse>(`/api/playlists/${encodeURIComponent(playlistId)}.json`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(request)
-    });
-  }
-
-  async createPlaylist(request: CreatePlaylistRequest): Promise<PlaylistTracksResponse> {
-    return this.fetch<PlaylistTracksResponse>('/api/playlists.json', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(request)
-    });
-  }
-
-  async deletePlaylist(playlistId: string): Promise<void> {
-    const url = `${this.baseUrl}/api/playlists/${encodeURIComponent(playlistId)}.json`;
-    const response = await fetch(url, {
-      method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${this.authToken}`
-      }
-    });
-
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({ error: response.statusText }));
-      throw new Error(error.error || `HTTP ${response.status}`);
-    }
-  }
-
-  async addTrackToPlaylist(playlistId: string, songId: string): Promise<PlaylistTracksResponse> {
-    return this.fetch<PlaylistTracksResponse>(`/api/playlists/${encodeURIComponent(playlistId)}/tracks.json`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ songId })
-    });
-  }
-
-  async removeTrackFromPlaylist(playlistId: string, trackIndex: number): Promise<PlaylistTracksResponse> {
-    return this.fetch<PlaylistTracksResponse>(`/api/playlists/${encodeURIComponent(playlistId)}/tracks/${trackIndex}.json`, {
-      method: 'DELETE'
-    });
-  }
-
   async getScanStatus(): Promise<ScanStatusResponse> {
     return this.fetch<ScanStatusResponse>('/api/scan/status.json');
-  }
-
-  async triggerScan(): Promise<ScanStatusResponse> {
-    return this.fetch<ScanStatusResponse>('/api/scan.json', { method: 'POST' });
-  }
-
-  async scrobble(songId: string, submission: boolean): Promise<void> {
-    await this.fetch('/api/scrobble.json', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ id: songId, submission })
-    });
   }
 
   getSongStreamUrl(songId: string, quality: StreamingQuality): string {
@@ -148,23 +75,18 @@ export class ApiService {
   }
 
   getAuthHeaders(): HeadersInit {
-    return {
-      'Authorization': `Bearer ${this.authToken}`
-    };
+    return {};
   }
 
   getCoverHeaders(): HeadersInit {
     return {
-      ...this.getAuthHeaders(),
       'Accept': ApiService.coverAcceptHeader
     };
   }
 
   async fetchSongBlob(songId: string, quality: StreamingQuality): Promise<Blob> {
     const url = this.getSongStreamUrl(songId, quality);
-    const response = await fetch(url, {
-      headers: this.getAuthHeaders()
-    });
+    const response = await fetch(url);
 
     if (!response.ok) {
       throw new Error(`Failed to fetch song: HTTP ${response.status}`);
@@ -192,16 +114,16 @@ let apiServiceInstance: ApiService | null = null;
 
 export function getApiService(): ApiService {
   if (!apiServiceInstance) {
-    apiServiceInstance = new ApiService('', '');
+    apiServiceInstance = new ApiService('');
   }
   return apiServiceInstance;
 }
 
-export function initApiService(baseUrl: string, authToken: string): ApiService {
+export function initApiService(baseUrl: string): ApiService {
   if (!apiServiceInstance) {
-    apiServiceInstance = new ApiService(baseUrl, authToken);
+    apiServiceInstance = new ApiService(baseUrl);
   } else {
-    apiServiceInstance.updateConfig(baseUrl, authToken);
+    apiServiceInstance.updateConfig(baseUrl);
   }
   return apiServiceInstance;
 }

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -52,7 +52,6 @@ export class AudioPlayerService {
   private quality: StreamingQuality = { format: 'raw' };
   private replayGainMode: ReplayGainMode = 'off';
   private replayGainPreamp: number = 0;
-  private scrobbleEnabled: boolean = true;
   private preventDownloadOnLowData: boolean = false;
   private networkType: 'normal' | 'low-data' | 'unknown' = 'unknown';
   private cachedTrackIds: Set<string> = new Set();
@@ -355,51 +354,12 @@ export class AudioPlayerService {
   }
 
   private async handleScrobble(trackId: string, submission: boolean): Promise<void> {
-    if (!this.scrobbleEnabled) return;
-
-    if (this.isOnline) {
-      try {
-        await getApiService().scrobble(trackId, submission);
-      } catch (error) {
-        console.error('Scrobble failed, saving for later', error);
-        // Only save submissions (actual scrobbles) to pending, not "now playing" notifications
-        if (submission) {
-          await storageService.addPendingScrobble(trackId, submission);
-        }
-      }
-    } else {
-      // Only save submissions (actual scrobbles) to pending when offline, not "now playing" notifications
-      if (submission) {
-        await storageService.addPendingScrobble(trackId, submission);
-      }
-    }
+    void trackId;
+    void submission;
   }
 
   private async processPendingScrobbles(): Promise<void> {
-    if (!this.isOnline) return;
-
-    try {
-      const pending = await storageService.getPendingScrobbles();
-      if (pending.length === 0) return;
-
-      console.log(`Processing ${pending.length} pending scrobbles`);
-      const api = getApiService();
-
-      for (const item of pending) {
-        try {
-          await api.scrobble(item.trackId, item.submission);
-          if (item.id !== undefined) {
-            await storageService.removePendingScrobble(item.id);
-          }
-        } catch (error) {
-          console.error('Failed to process pending scrobble', error);
-          // Stop processing if we hit an error (likely offline again or API issue)
-          break;
-        }
-      }
-    } catch (error) {
-      console.error('Error processing pending scrobbles', error);
-    }
+    return;
   }
 
   // Idle-release helpers: free the audio Blob URL after a long pause to release
@@ -1016,7 +976,7 @@ export class AudioPlayerService {
   }
 
   setScrobbleEnabled(enabled: boolean): void {
-    this.scrobbleEnabled = enabled;
+    void enabled;
   }
 
   setNetworkType(type: 'normal' | 'low-data' | 'unknown'): void {

--- a/Meziantou.MusicApp.WebPlayer/src/types/app.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/types/app.ts
@@ -4,12 +4,10 @@ import type { PlaylistSummary, TrackInfo } from './api';
 
 export interface AppSettings {
   serverUrl: string;
-  authToken: string;
   normalQuality: StreamingQuality;
   lowDataQuality: StreamingQuality;
   downloadQuality: StreamingQuality;
   preventDownloadOnLowData: boolean;
-  scrobbleEnabled: boolean;
   hideCoverArt: boolean;
   replayGainMode: ReplayGainMode;
   replayGainPreamp: number; // in dB

--- a/README.md
+++ b/README.md
@@ -9,15 +9,14 @@ This repository contains a complete music streaming solution consisting of a bac
 A dual-API music server supporting both **Subsonic** and **Jellyfin** protocols. It serves music files from a local directory and provides features like:
 - Dual API support (Subsonic & Jellyfin)
 - On-the-fly transcoding with FFmpeg
-- Last.fm scrobbling
 - ReplayGain support
+- Read-only API surface
 
 ### [Meziantou.MusicApp.WebPlayer](Meziantou.MusicApp.WebPlayer/README.md)
 
 A modern, web-based music player designed to work with the server. Features include:
 - Progressive Web App (PWA) support
 - Offline mode with caching
-- Drag and drop playlist management
 - Dark theme
 - Background sync and auto-resume
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A dual-API music server supporting both **Subsonic** and **Jellyfin** protocols.
 - Dual API support (Subsonic & Jellyfin)
 - On-the-fly transcoding with FFmpeg
 - ReplayGain support
-- Read-only API surface
+- Read-only API surface with manual library rescan support
 
 ### [Meziantou.MusicApp.WebPlayer](Meziantou.MusicApp.WebPlayer/README.md)
 


### PR DESCRIPTION
## Why
The app needs to run in a strict read-only mode across both server APIs and the web player. This change also removes token authentication enforcement so clients can connect with any token value.

## What changed
- Removed REST write routes from `RestApiController`:
  - playlist mutations (create, update, delete, rename, add/remove track)
  - `POST /api/scan.json`
  - `POST /api/scrobble.json`
- Kept Subsonic write-style routes for compatibility, but made them return the standard read-only Subsonic error for:
  - `startScan.view`, `createPlaylist.view`, `updatePlaylist.view`, `deletePlaylist.view`
- Removed Subsonic `scrobble.view` route entirely.
- Removed token validation from REST, Jellyfin, and Subsonic auth middleware.
- Updated Jellyfin auth behavior to accept any credential value and stop requiring configured token matching.
- Made the web player read-only by removing server mutation actions and related UI affordances:
  - playlist create/delete controls
  - track drag-to-playlist and remove-from-playlist actions
  - rescan action in settings
  - scrobble write usage
- Removed web player token usage:
  - removed auth token setting/plumbing
  - stopped sending `Authorization` headers from API calls
- Updated integration tests and docs to reflect read-only and no token-auth enforcement behavior.

## Notes for reviewers
- Subsonic request-shape validation (`u`, `v`, `c`) is still enforced for protocol compatibility, but token/password matching is no longer enforced.
- This is intentionally a large deletion-heavy diff because write paths and their UI hooks were removed end-to-end.