### PR TITLE
Display short commit SHA in WebPlayer version

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/vite.config.ts
+++ b/Meziantou.MusicApp.WebPlayer/vite.config.ts
@@ -12,9 +12,13 @@ function getCommitHash(): string {
   }
 }
 
+function getShortCommitHash(commitHash: string): string {
+  return commitHash.slice(0, 7);
+}
+
 export default defineConfig({
   define: {
-    __COMMIT_HASH__: JSON.stringify(process.env.VITE_COMMIT_HASH || getCommitHash()),
+    __COMMIT_HASH__: JSON.stringify(getShortCommitHash(process.env.VITE_COMMIT_HASH || getCommitHash())),
   },
   test: {
     globals: true,


### PR DESCRIPTION
The version label in the WebPlayer can show a full 40-character commit SHA when `VITE_COMMIT_HASH` is provided, which is noisy and harder to read in the UI.

This change normalizes the displayed version hash to a short SHA:

- Add `getShortCommitHash` in `vite.config.ts`.
- Apply it when defining `__COMMIT_HASH__` so both env-provided and git-derived values are rendered as 7 characters.
- Keep existing fallback behavior (`unknown`) unchanged.