### PR TITLE
Optimize Web Player CPU and memory usage hotspots

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
@@ -5,6 +5,34 @@ import { useApp } from '../hooks';
 
 const COVER_PLACEHOLDER_SVG = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='#666'><path d='M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z'/></svg>";
 const COVER_PLACEHOLDER_DATA_URI = `data:image/svg+xml,${encodeURIComponent(COVER_PLACEHOLDER_SVG)}`;
+const inFlightCoverRequests = new Map<string, Promise<Blob | null>>();
+
+function fetchCoverBlob(trackId: string, size: number): Promise<Blob | null> {
+  const key = `${trackId}:${size}`;
+  const existing = inFlightCoverRequests.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const request = (async () => {
+    const api = getApiService();
+    const coverUrl = api.getSongCoverUrl(trackId, size);
+    const response = await fetch(coverUrl, { headers: api.getCoverHeaders() });
+    if (!response.ok) {
+      if (response.status === 404) {
+        await storageService.addMissingCover(trackId);
+      }
+      return null;
+    }
+
+    return response.blob();
+  })().finally(() => {
+    inFlightCoverRequests.delete(key);
+  });
+
+  inFlightCoverRequests.set(key, request);
+  return request;
+}
 
 interface CoverImageProps {
   trackId: string;
@@ -24,6 +52,7 @@ export function CoverImage({
   const { cachedTrackIds, settings } = useApp();
   const [coverSrc, setCoverSrc] = useState(COVER_PLACEHOLDER_DATA_URI);
   const coverBlobUrlRef = useRef<string | null>(null);
+  const isTrackCached = cachedTrackIds.has(trackId);
 
   // Always revoke any blob URL on unmount so virtualized rows don't leak
   // when they scroll out of view without re-running the main effect.
@@ -71,7 +100,6 @@ export function CoverImage({
 
         // 2. If not in cache, check if we should download it
         const networkType = getNetworkType();
-        const isCached = cachedTrackIds.has(trackId);
         
         // If offline and not cached, we can't do anything
         if (!navigator.onLine) {
@@ -80,26 +108,20 @@ export function CoverImage({
         }
 
         // In low data mode, only download if track is cached or playing (we assume if we are showing cover, we might want it)
-        const shouldDownload = networkType !== 'low-data' || isCached;
+        const shouldDownload = networkType !== 'low-data' || isTrackCached;
 
         if (!shouldDownload) {
           if (!cancelled) setCoverSrc(COVER_PLACEHOLDER_DATA_URI);
           return;
         }
 
-        // 3. Fetch from server
-        const api = getApiService();
-        const coverUrl = api.getSongCoverUrl(trackId, size);
-        
-        const response = await fetch(coverUrl, { headers: api.getCoverHeaders() });
-        if (!response.ok) {
-          if (response.status === 404) {
-            storageService.addMissingCover(trackId).catch(console.error);
+        const blob = await fetchCoverBlob(trackId, size);
+        if (!blob) {
+          if (!cancelled) {
+            setCoverSrc(COVER_PLACEHOLDER_DATA_URI);
           }
-          throw new Error('Failed to load cover');
+          return;
         }
-        
-        const blob = await response.blob();
         
         // 4. Save to cache
         // We don't await this to not block rendering, but we should catch errors
@@ -123,7 +145,7 @@ export function CoverImage({
     return () => {
       cancelled = true;
     };
-  }, [trackId, size, cachedTrackIds, settings.hideCoverArt]);
+  }, [trackId, size, isTrackCached, settings.hideCoverArt]);
 
   if (settings.hideCoverArt) {
     return null;

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { RepeatMode } from '../types';
-import { formatDuration, throttle } from '../utils';
+import { formatDuration } from '../utils';
 import { useApp } from '../hooks';
 import { CoverImage } from './CoverImage';
 
@@ -69,6 +69,14 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
   const [isVolumePopoverVisible, setIsVolumePopoverVisible] = useState(false);
   const volumePopoverTimeoutRef = useRef<number | undefined>(undefined);
 
+  useEffect(() => {
+    return () => {
+      if (volumePopoverTimeoutRef.current) {
+        window.clearTimeout(volumePopoverTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const showVolumePopover = () => {
     setIsVolumePopoverVisible(true);
     if (volumePopoverTimeoutRef.current) {
@@ -118,9 +126,6 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
   const progressPercent = playerState.duration > 0
     ? (playerState.currentTime / playerState.duration) * 100
     : 0;
-
-  const throttledTimeUpdate = throttle(() => {}, 250);
-  throttledTimeUpdate();
 
   return (
     <div className="player-bar">

--- a/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
+import { memo, useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import type { TrackInfo, AppSettings } from '../types';
 import { formatDuration, normalizeSearch, debounce, sortTracks } from '../utils';
 import { useApp } from '../hooks';
@@ -11,6 +11,7 @@ type SortDirection = Parameters<typeof sortTracks>[2];
 
 const ITEM_HEIGHT = 56;
 const BUFFER_SIZE = 5;
+const SCROLL_SAVE_DELAY_MS = 200;
 
 function getTrackDownloadFileName(track: TrackInfo): string {
   const normalizedPath = track.path.replace(/\\/g, '/');
@@ -48,6 +49,9 @@ export function TrackList() {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; track: TrackInfo; index: number } | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const lastRestoredPlaylistId = useRef<string | null>(null);
+  const scrollPositionsRef = useRef<Record<string, number> | null>(null);
+  const scrollSaveTimeoutRef = useRef<number | null>(null);
+  const scrollRafRef = useRef<number | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const [sortOption, setSortOption] = useState<SortOption>('added');
@@ -97,32 +101,92 @@ export function TrackList() {
     return out;
   }, [searchQuery, sortedTracks, searchHaystacks]);
 
-  const handleScroll = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
+  const trackIndexes = useMemo(() => {
+    const out = new Map<TrackInfo, number>();
+    for (let i = 0; i < currentPlaylistTracks.length; i++) {
+      out.set(currentPlaylistTracks[i], i);
+    }
+    return out;
+  }, [currentPlaylistTracks]);
 
-    const scrollTop = container.scrollTop;
-    const containerHeight = container.clientHeight;
+  const getStoredScrollPositions = useCallback(() => {
+    if (!scrollPositionsRef.current) {
+      try {
+        const raw = localStorage.getItem('playlistScrollPositions');
+        scrollPositionsRef.current = raw ? JSON.parse(raw) as Record<string, number> : {};
+      } catch {
+        scrollPositionsRef.current = {};
+      }
+    }
 
+    return scrollPositionsRef.current;
+  }, []);
+
+  const persistScrollPositions = useCallback(() => {
+    if (!scrollPositionsRef.current) {
+      scrollSaveTimeoutRef.current = null;
+      return;
+    }
+
+    localStorage.setItem('playlistScrollPositions', JSON.stringify(scrollPositionsRef.current));
+    scrollSaveTimeoutRef.current = null;
+  }, []);
+
+  const saveScrollPosition = useCallback((playlistId: string, scrollTop: number) => {
+    const positions = getStoredScrollPositions();
+    positions[playlistId] = scrollTop;
+
+    if (scrollSaveTimeoutRef.current !== null) {
+      window.clearTimeout(scrollSaveTimeoutRef.current);
+    }
+
+    scrollSaveTimeoutRef.current = window.setTimeout(persistScrollPositions, SCROLL_SAVE_DELAY_MS);
+  }, [getStoredScrollPositions, persistScrollPositions]);
+
+  const updateVisibleRange = useCallback((scrollTop: number, containerHeight: number) => {
     const visibleStart = Math.max(0, Math.floor(scrollTop / ITEM_HEIGHT) - BUFFER_SIZE);
     const visibleEnd = Math.min(
       filteredTracks.length,
       Math.ceil((scrollTop + containerHeight) / ITEM_HEIGHT) + BUFFER_SIZE
     );
 
-    setVisibleRange({ start: visibleStart, end: visibleEnd });
+    setVisibleRange(prev => {
+      if (prev.start === visibleStart && prev.end === visibleEnd) {
+        return prev;
+      }
 
-    // Save scroll position
-    if (currentPlaylistId) {
-      const positions = JSON.parse(localStorage.getItem('playlistScrollPositions') || '{}');
-      positions[currentPlaylistId] = scrollTop;
-      localStorage.setItem('playlistScrollPositions', JSON.stringify(positions));
+      return { start: visibleStart, end: visibleEnd };
+    });
+  }, [filteredTracks.length]);
+
+  const handleScroll = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    if (scrollRafRef.current !== null) {
+      return;
     }
-  }, [filteredTracks.length, currentPlaylistId]);
+
+    scrollRafRef.current = window.requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+
+      const activeContainer = scrollContainerRef.current;
+      if (!activeContainer) {
+        return;
+      }
+
+      const scrollTop = activeContainer.scrollTop;
+      updateVisibleRange(scrollTop, activeContainer.clientHeight);
+
+      if (currentPlaylistId) {
+        saveScrollPosition(currentPlaylistId, scrollTop);
+      }
+    });
+  }, [currentPlaylistId, saveScrollPosition, updateVisibleRange]);
 
   useEffect(() => {
     handleScroll();
-  }, [filteredTracks, handleScroll]);
+  }, [filteredTracks.length, handleScroll]);
 
   // Handle window resize to recalculate visible range
   useEffect(() => {
@@ -141,9 +205,9 @@ export function TrackList() {
   useEffect(() => {
     if (currentPlaylistId && scrollContainerRef.current && filteredTracks.length > 0) {
       if (lastRestoredPlaylistId.current !== currentPlaylistId) {
-        const positions = JSON.parse(localStorage.getItem('playlistScrollPositions') || '{}');
+        const positions = getStoredScrollPositions();
         const saved = positions[currentPlaylistId];
-        if (saved) {
+        if (typeof saved === 'number') {
           scrollContainerRef.current.scrollTop = saved;
         } else {
           scrollContainerRef.current.scrollTop = 0;
@@ -151,7 +215,20 @@ export function TrackList() {
         lastRestoredPlaylistId.current = currentPlaylistId;
       }
     }
-  }, [currentPlaylistId, filteredTracks]);
+  }, [currentPlaylistId, filteredTracks.length, getStoredScrollPositions]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollRafRef.current !== null) {
+        window.cancelAnimationFrame(scrollRafRef.current);
+      }
+
+      if (scrollSaveTimeoutRef.current !== null) {
+        window.clearTimeout(scrollSaveTimeoutRef.current);
+        persistScrollPositions();
+      }
+    };
+  }, [persistScrollPositions]);
 
   // Listen for focus search input requests
   useEffect(() => {
@@ -328,7 +405,7 @@ export function TrackList() {
         <div className="virtual-content" style={{ height: totalHeight }}>
           <div className="track-list" style={{ transform: `translateY(${visibleRange.start * ITEM_HEIGHT}px)` }}>
             {visibleTracks.map((track, i) => {
-              const originalIndex = currentPlaylistTracks.indexOf(track);
+              const originalIndex = trackIndexes.get(track) ?? (visibleRange.start + i);
               const isCached = cachedTrackIds.has(track.id);
               const isPlaying = track.id === playerState.currentTrack?.id &&
                 currentPlaylistId === playingPlaylistId;
@@ -336,7 +413,7 @@ export function TrackList() {
 
               return (
                 <TrackItem
-                  key={`${track.id}-${visibleRange.start + i}`}
+                  key={`${track.id}-${originalIndex}`}
                   track={track}
                   index={originalIndex}
                   isCached={isCached}
@@ -419,7 +496,7 @@ interface TrackItemProps {
   onTogglePlay: () => void;
 }
 
-function TrackItem({
+const TrackItem = memo(function TrackItem({
   track,
   index,
   isCached,
@@ -520,7 +597,7 @@ function TrackItem({
       </button>
     </div>
   );
-}
+});
 
 interface ContextMenuProps {
   x: number;

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -410,7 +410,7 @@ export function AppProvider({ children }: AppProviderProps) {
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [isOnline, settings.serverUrl, cachedTrackIds, currentPlaylistId]);
+  }, [isOnline, settings.serverUrl]);
 
   // Sync playlists periodically
   useEffect(() => {
@@ -423,7 +423,7 @@ export function AppProvider({ children }: AppProviderProps) {
     }, 5 * 60 * 1000);
 
     return () => clearInterval(interval);
-  }, [isInitialized, settings.serverUrl, isOnline, cachedTrackIds, currentPlaylistId]);
+  }, [isInitialized, settings.serverUrl, isOnline]);
 
   async function syncPlaylistsInternal() {
     if (!isOnline) return;

--- a/Meziantou.MusicApp.WebPlayer/src/services/download-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/download-service.ts
@@ -16,9 +16,18 @@ type DownloadCallback = (progress: DownloadProgress) => void;
 class DownloadService {
   private downloadQueue: Map<string, { track: TrackInfo; playlistIds: Set<string>; quality: StreamingQuality }> = new Map();
   private activeDownloads: Set<string> = new Set();
-  private maxConcurrentDownloads = 8;
+  private maxConcurrentDownloads = this.computeMaxConcurrentDownloads();
   private callbacks: Set<DownloadCallback> = new Set();
   private cachedTrackIds: Set<string> = new Set();
+
+  private computeMaxConcurrentDownloads(): number {
+    const logicalCores = globalThis.navigator?.hardwareConcurrency;
+    if (typeof logicalCores !== 'number' || !Number.isFinite(logicalCores)) {
+      return 6;
+    }
+
+    return Math.max(2, Math.min(8, Math.floor(logicalCores / 2)));
+  }
 
   async init(): Promise<void> {
     this.cachedTrackIds = await storageService.getCachedTrackIds();


### PR DESCRIPTION
Reduce avoidable CPU and RAM usage in the Web Player during common flows (scrolling large playlists, rendering covers, and background sync) while keeping current UX and playback behavior.

## What changed

- Optimized `TrackList` hot paths:
  - Replaced per-scroll `localStorage` parse/stringify with cached state plus delayed persistence.
  - Batched scroll work with `requestAnimationFrame` and avoided redundant visible-range state writes.
  - Removed per-row `indexOf` lookup by precomputing track indexes.
  - Memoized `TrackItem` and stabilized row keys to reduce rerenders.
- Optimized `CoverImage` loading:
  - Added in-flight cover fetch deduplication so multiple rows requesting the same cover share one network request.
  - Narrowed effect dependencies to avoid unrelated reruns.
- Removed unnecessary per-render work in `PlayerBar` by deleting a no-op throttling path and adding timer cleanup.
- Reduced background churn in `useApp` by tightening sync effect dependencies so interval/listener setup is not recreated by unrelated state changes.
- Tuned download memory/CPU behavior in `download-service` by setting concurrent download limits from device hardware concurrency (bounded range).

## Notes for reviewers

- This is a balanced optimization pass: no intentional feature or UX changes.
- `npm test` and `npm run build` pass for the WebPlayer.
- `npm run lint` is not currently runnable in this project because `eslint` is not installed in dependencies.