### PR TITLE
Add track list column visibility settings

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/README.md
+++ b/Meziantou.MusicApp.WebPlayer/README.md
@@ -27,6 +27,7 @@ Configuration
 - Low Data Quality: Lower bitrate for cellular/slow networks
 - Download Quality: Quality for offline cached tracks
 - Auto-download: Enable background downloading of new tracks
+- Interface toggles: Hide cover art, track index, duration, and cache status in the track list
 
 ## Playback Algorithm
 
@@ -58,7 +59,7 @@ In the future, I want to support more backend servers like Subsonic, Airsonic, s
 - When a music is playint an indicator
 
 # Track list
-- List of tracks with cover, title, artist, album, duration
+- List of tracks with configurable columns (cover, track index, title, artist, album, cache status, duration)
 - Double-click on a track to play it
 - Support playlists with thousands of tracks (performance optimized)
 - Search to filter tracks by title, artist, album (accent insensitive, case insensitive, partial matches, etc.)

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -205,6 +205,42 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
               </label>
               <small>Do not load cover images to save memory and data</small>
             </div>
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  id="hide-track-index"
+                  checked={formData.hideTrackIndex}
+                  onChange={(e) => handleInputChange('hideTrackIndex', e.target.checked)}
+                />
+                Hide Track Index
+              </label>
+              <small>Hide track numbers and the left playback indicator column</small>
+            </div>
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  id="hide-track-duration"
+                  checked={formData.hideTrackDuration}
+                  onChange={(e) => handleInputChange('hideTrackDuration', e.target.checked)}
+                />
+                Hide Track Duration
+              </label>
+              <small>Hide the duration column in the track list</small>
+            </div>
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  id="hide-track-cache-status"
+                  checked={formData.hideTrackCacheStatus}
+                  onChange={(e) => handleInputChange('hideTrackCacheStatus', e.target.checked)}
+                />
+                Hide Cache Status
+              </label>
+              <small>Hide the offline availability icon in the track list</small>
+            </div>
           </section>
 
           <section className="settings-section">

--- a/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
@@ -544,14 +544,16 @@ const TrackItem = memo(function TrackItem({
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}
     >
-      <div className="track-index-container">
-        <span className="track-index">{index + 1}</span>
-        <PlayingIndicator
-          isPlaying={isPlaying}
-          isPaused={!isPlayerPlaying}
-          onTogglePlay={onTogglePlay}
-        />
-      </div>
+      {!settings.hideTrackIndex && (
+        <div className="track-index-container">
+          <span className="track-index">{index + 1}</span>
+          <PlayingIndicator
+            isPlaying={isPlaying}
+            isPaused={!isPlayerPlaying}
+            onTogglePlay={onTogglePlay}
+          />
+        </div>
+      )}
 
       <CoverImage
         trackId={track.id}
@@ -576,13 +578,15 @@ const TrackItem = memo(function TrackItem({
           {track.artists || 'Unknown Artist'} • {track.album || 'Unknown Album'}
         </span>
       </div>
-      {isCached && (
+      {!settings.hideTrackCacheStatus && isCached && (
         <svg className="cached-icon" viewBox="0 0 24 24" fill="currentColor" aria-label="Available offline">
           <title>Available offline</title>
           <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
         </svg>
       )}
-      <span className="track-duration">{formatDuration(track.duration)}</span>
+      {!settings.hideTrackDuration && (
+        <span className="track-duration">{formatDuration(track.duration)}</span>
+      )}
       <button
         className="track-options-btn"
         onClick={(e) => {

--- a/Meziantou.MusicApp.WebPlayer/src/constants.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/constants.ts
@@ -7,6 +7,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
   downloadQuality: { format: 'opus', maxBitRate: 160 },
   preventDownloadOnLowData: false,
   hideCoverArt: false,
+  hideTrackIndex: false,
+  hideTrackDuration: false,
+  hideTrackCacheStatus: false,
   replayGainMode: 'off',
   replayGainPreamp: 0,
   showReplayGainWarning: true

--- a/Meziantou.MusicApp.WebPlayer/src/types/app.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/types/app.ts
@@ -9,6 +9,9 @@ export interface AppSettings {
   downloadQuality: StreamingQuality;
   preventDownloadOnLowData: boolean;
   hideCoverArt: boolean;
+  hideTrackIndex: boolean;
+  hideTrackDuration: boolean;
+  hideTrackCacheStatus: boolean;
   replayGainMode: ReplayGainMode;
   replayGainPreamp: number; // in dB
   showReplayGainWarning: boolean;


### PR DESCRIPTION
## Why
The track list only had a toggle for cover art, which made it hard to simplify the UI further for users who want a minimal view. This adds controls for additional columns so users can tailor the track list layout.

## What changed
- Added new `AppSettings` flags and defaults for:
  - `hideTrackIndex`
  - `hideTrackDuration`
  - `hideTrackCacheStatus`
- Extended **Settings -> Interface** with checkboxes for the new toggles.
- Updated `TrackList` rendering to conditionally hide:
  - the track index / play-indicator column,
  - the duration column,
  - the cache status icon.
- Updated WebPlayer README to document configurable track list columns.

## Notes
Settings loading already merges stored settings with defaults, so existing users automatically get `false` defaults for the new toggles.