### PR TITLE
Add force library rescan and needs-rescan virtual playlist

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
@@ -33,6 +33,30 @@ public class RestApiIntegrationTests
     }
 
     [Fact]
+    public async Task TriggerScan_WithForceQuery_WithValidAuth_ReturnsOk()
+    {
+        await using var app = AppTestContext.Create();
+        using var response = await app.Client.PostAsync("/api/scan.json?force=true", content: null, app.CancellationToken);
+        InlineSnapshot
+            .WithSerializer(serializer => serializer.ScrubJsonValue("$.isScanning", node => "[redacted]"))
+            .Validate(response, """
+                StatusCode: 200 (OK)
+                Headers:
+                  Cache-Control: no-store, must-revalidate, no-cache
+                Content:
+                  Headers:
+                    Content-Type: application/json; charset=utf-8
+                  Value:
+                    {
+                      "isScanning": "[redacted]",
+                      "isInitialScanCompleted": true,
+                      "scanCount": 0,
+                      "invalidPlaylists": []
+                    }
+                """);
+    }
+
+    [Fact]
     public async Task ScrobbleRoute_IsNotAvailable()
     {
         await using var app = AppTestContext.Create();

--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -574,6 +574,101 @@ public partial class MusicLibraryServiceTests
     }
 
     [Fact]
+    public async Task ScanMusicLibrary_IncrementalScan_ReScansCachedFilesWithMissingCoreMetadata()
+    {
+        using var tempDir = TemporaryDirectory.Create();
+        var musicPath = tempDir / "music";
+        var cachePath = tempDir / "cache";
+        Directory.CreateDirectory(musicPath);
+
+        var musicLibrary = new MusicLibraryTestContext(musicPath);
+        musicLibrary.CreateTestMp3File("TestSong.mp3", title: "Original Title", artist: "Test Artist", albumArtist: "Test Artist", album: "Test Album", genre: "Rock", year: 2024, track: 1);
+
+        {
+            await using var initialContext = AppTestContext.Create();
+            initialContext.Configure<MusicServerSettings>(settings =>
+            {
+                settings.CachePath = cachePath;
+                settings.MusicFolderPath = musicPath;
+            });
+
+            _ = await initialContext.ScanCatalog();
+        }
+
+        var musicCachePath = cachePath / "cache.json";
+        var cacheContent = await File.ReadAllTextAsync(musicCachePath, TestContext.Current.CancellationToken);
+        var cacheJson = JsonNode.Parse(cacheContent);
+        Assert.NotNull(cacheJson);
+        Assert.NotNull(cacheJson["Songs"]);
+        Assert.NotNull(cacheJson["Songs"]![0]);
+
+        cacheJson["Songs"]![0]!["Title"] = "Stale Cached Title";
+        cacheJson["Songs"]![0]!["Duration"] = "00:00:00";
+        await File.WriteAllTextAsync(musicCachePath, cacheJson.ToJsonString(), TestContext.Current.CancellationToken);
+
+        await using var testContext = AppTestContext.Create();
+        testContext.Configure<MusicServerSettings>(settings =>
+        {
+            settings.CachePath = cachePath;
+            settings.MusicFolderPath = musicPath;
+        });
+
+        var service = await testContext.ScanCatalog();
+        var song = Assert.Single(service.GetAllSongs());
+        Assert.Equal("Original Title", song.Title);
+    }
+
+    [Fact]
+    public async Task ScanMusicLibrary_ForceScan_IgnoresReusableCache()
+    {
+        using var tempDir = TemporaryDirectory.Create();
+        var musicPath = tempDir / "music";
+        var cachePath = tempDir / "cache";
+        Directory.CreateDirectory(musicPath);
+
+        var musicLibrary = new MusicLibraryTestContext(musicPath);
+        musicLibrary.CreateTestMp3File("TestSong.mp3", title: "Original Title", artist: "Test Artist", albumArtist: "Test Artist", album: "Test Album", genre: "Rock", year: 2024, track: 1);
+
+        {
+            await using var initialContext = AppTestContext.Create();
+            initialContext.Configure<MusicServerSettings>(settings =>
+            {
+                settings.CachePath = cachePath;
+                settings.MusicFolderPath = musicPath;
+            });
+
+            _ = await initialContext.ScanCatalog();
+        }
+
+        var musicCachePath = cachePath / "cache.json";
+        var cacheContent = await File.ReadAllTextAsync(musicCachePath, TestContext.Current.CancellationToken);
+        var cacheJson = JsonNode.Parse(cacheContent);
+        Assert.NotNull(cacheJson);
+        Assert.NotNull(cacheJson["Songs"]);
+        Assert.NotNull(cacheJson["Songs"]![0]);
+
+        cacheJson["Songs"]![0]!["Title"] = "Stale Cached Title";
+        cacheJson["Songs"]![0]!["Duration"] = "00:01:00";
+        await File.WriteAllTextAsync(musicCachePath, cacheJson.ToJsonString(), TestContext.Current.CancellationToken);
+
+        await using var testContext = AppTestContext.Create();
+        testContext.Configure<MusicServerSettings>(settings =>
+        {
+            settings.CachePath = cachePath;
+            settings.MusicFolderPath = musicPath;
+        });
+
+        var service = await testContext.ScanCatalog();
+        var cachedSong = Assert.Single(service.GetAllSongs());
+        Assert.Equal("Stale Cached Title", cachedSong.Title);
+
+        await service.ScanMusicLibrary(force: true);
+
+        var refreshedSong = Assert.Single(service.GetAllSongs());
+        Assert.Equal("Original Title", refreshedSong.Title);
+    }
+
+    [Fact]
     public async Task ScanMusicLibrary_IncrementalScan_DetectsNewFiles()
     {
         await using var testContext = AppTestContext.Create();
@@ -1177,6 +1272,42 @@ public partial class MusicLibraryServiceTests
         Assert.Equal("virtual:no-replay-gain", noReplayGainPlaylist.Id);
         Assert.Equal("⚠️ No Replay Gain", noReplayGainPlaylist.Name);
         Assert.Equal(1, noReplayGainPlaylist.SongCount);
+    }
+
+    [Fact]
+    public async Task GetPlaylists_IncludesNeedsRescanVirtualPlaylist_WhenSongsWithMissingCoreMetadataExist()
+    {
+        await using var testContext = AppTestContext.Create();
+        testContext.MusicLibrary.AddFolder("music");
+        testContext.MusicLibrary.AddFile("music/invalid.mp3", [0x00, 0x01, 0x02, 0x03]);
+
+        var service = await testContext.ScanCatalog();
+
+        var playlists = service.GetPlaylists().ToList();
+
+        var needsRescanPlaylist = playlists.FirstOrDefault(p => p.Id == Playlist.NeedsRescanPlaylistId);
+        Assert.NotNull(needsRescanPlaylist);
+        Assert.Equal(Playlist.NeedsRescanPlaylistId, needsRescanPlaylist.Id);
+        Assert.Equal("⚠️ Needs Rescan", needsRescanPlaylist.Name);
+        Assert.Equal(1, needsRescanPlaylist.SongCount);
+    }
+
+    [Fact]
+    public async Task GetPlaylist_NeedsRescanVirtualPlaylist_ReturnsOnlySongsWithMissingCoreMetadata()
+    {
+        await using var testContext = AppTestContext.Create();
+        testContext.MusicLibrary.AddFolder("music");
+        testContext.MusicLibrary.AddFile("music/invalid.mp3", [0x00, 0x01, 0x02, 0x03]);
+
+        var service = await testContext.ScanCatalog();
+
+        var playlist = service.GetPlaylist(Playlist.NeedsRescanPlaylistId);
+
+        Assert.NotNull(playlist);
+        Assert.Equal("⚠️ Needs Rescan", playlist.Name);
+        Assert.Equal(1, playlist.SongCount);
+        Assert.Equal(1, playlist.Items.Count);
+        Assert.All(playlist.Items, item => Assert.Equal(0, item.Song.Duration));
     }
 
     [Fact]

--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -352,10 +352,10 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
     /// <summary>Trigger a library scan</summary>
     [HttpPost("scan.json")]
     [ProducesResponseType<ScanStatusResponse>(StatusCodes.Status200OK)]
-    public ActionResult<ScanStatusResponse> TriggerScan()
+    public ActionResult<ScanStatusResponse> TriggerScan([FromQuery] bool force = false)
     {
         // Trigger scan in background
-        _ = Task.Run(() => library.ScanMusicLibrary());
+        _ = Task.Run(() => library.ScanMusicLibrary(force));
 
         return Ok(new ScanStatusResponse
         {

--- a/Meziantou.MusicApp.Server/Models/Playlist.cs
+++ b/Meziantou.MusicApp.Server/Models/Playlist.cs
@@ -6,6 +6,7 @@ public sealed class Playlist
     public const string AllSongsPlaylistId = "virtual:all-songs";
     public const string MissingTracksPlaylistId = "virtual:missing-tracks";
     public const string NoReplayGainPlaylistId = "virtual:no-replay-gain";
+    public const string NeedsRescanPlaylistId = "virtual:needs-rescan";
 
     public required string Id { get; init; }
     public required string Name { get; init; }

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -145,7 +145,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         return await MusicCatalog.Create(content, RootFolder, coverArtCachePath);
     }
 
-    public async Task ScanMusicLibrary()
+    public async Task ScanMusicLibrary(bool force = false)
     {
         using var activity = MusicLibraryActivitySource.Instance.StartActivity("ScanMusicLibrary");
         var rootFolder = RootFolder;
@@ -186,11 +186,13 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             activity?.SetTag("music.library.audio_files", audioFiles.Length);
 
             // Build a lookup dictionary from cached songs for incremental scanning
-            var cachedSongsByPath = _cachedSerializableCatalog?.Songs
-                .ToImmutableDictionary(s => s.RelativePath, s => s, StringComparer.Ordinal)
+            var cachedSongsByPath = force
+                ? ImmutableDictionary<string, SerializableSong>.Empty
+                : _cachedSerializableCatalog?.Songs.ToImmutableDictionary(s => s.RelativePath, s => s, StringComparer.Ordinal)
                 ?? [];
 
             activity?.SetTag("music.library.cached_songs", cachedSongsByPath.Count);
+            activity?.SetTag("music.library.force_rescan", force);
 
             IndexerContext CreateContext(FullPath path) => new IndexerContext(rootFolder, path, library, cachedSongsByPath);
 
@@ -326,7 +328,8 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             // Check if we have a cached version of this song and if the file hasn't changed
             if (context.CachedSongsByPath.TryGetValue(relativePath, out var cachedSong) &&
                 TruncateMilliseconds(cachedSong.FileLastWriteTime) >= TruncateMilliseconds(fileLastWriteTime) &&
-                cachedSong.FileSize == fileInfo.Length)
+                cachedSong.FileSize == fileInfo.Length &&
+                !HasMissingCoreMetadata(cachedSong))
             {
                 activity?.SetTag("music.file.from_cache", true);
 
@@ -419,6 +422,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                 newSong.Year = tags.Year ?? 0;
                 newSong.Track = tags.TrackNumber ?? 0;
                 newSong.Lyrics = tags.Lyrics;
+                newSong.Duration = tags.Duration ?? TimeSpan.Zero;
 
                 newSong.Isrc = tags.Isrc;
 
@@ -710,6 +714,14 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             playlists.Insert(1, missingTracksPlaylist);
         }
 
+        // Add "Needs Rescan" virtual playlist if there are tracks with missing core metadata
+        var needsRescanPlaylist = CreateNeedsRescanVirtualPlaylist();
+        if (needsRescanPlaylist.SongCount > 0)
+        {
+            var needsRescanInsertIndex = missingTracksPlaylist.SongCount > 0 ? 2 : 1;
+            playlists.Insert(Math.Min(needsRescanInsertIndex, playlists.Count), needsRescanPlaylist);
+        }
+
         // Add "No Replay Gain" virtual playlist if there are songs without replay gain
         var noReplayGainPlaylist = CreateNoReplayGainVirtualPlaylist();
         if (noReplayGainPlaylist.SongCount > 0)
@@ -738,6 +750,11 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             if (id == Playlist.NoReplayGainPlaylistId)
             {
                 return CreateNoReplayGainVirtualPlaylist();
+            }
+
+            if (id == Playlist.NeedsRescanPlaylistId)
+            {
+                return CreateNeedsRescanVirtualPlaylist();
             }
 
             // Future virtual playlists can be added here
@@ -848,6 +865,37 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             Changed = DateTime.UtcNow,
             CoverArt = items.FirstOrDefault()?.Song.CoverArt,
             Comment = "Virtual playlist containing tracks without replay gain information",
+            Items = items,
+        };
+    }
+
+    private Playlist CreateNeedsRescanVirtualPlaylist()
+    {
+        var songsWithMissingCoreMetadata = _catalog.Songs
+            .Where(HasMissingCoreMetadata)
+            .OrderBy(s => s.Artist, StringComparer.Ordinal)
+            .ThenBy(s => s.Album, StringComparer.Ordinal)
+            .ThenBy(s => s.Track ?? 0)
+            .ThenBy(s => s.Title, StringComparer.Ordinal)
+            .ToList();
+
+        var items = songsWithMissingCoreMetadata.Select(song => new PlaylistItem
+        {
+            Song = song,
+            AddedDate = song.Created,
+        }).ToList();
+
+        return new Playlist
+        {
+            Id = Playlist.NeedsRescanPlaylistId,
+            Name = "⚠️ Needs Rescan",
+            Path = string.Empty,
+            SongCount = items.Count,
+            Duration = items.Sum(i => i.Song.Duration),
+            Created = DateTime.UtcNow,
+            Changed = DateTime.UtcNow,
+            CoverArt = items.FirstOrDefault()?.Song.CoverArt,
+            Comment = "Virtual playlist containing tracks with missing core metadata that should be rescanned",
             Items = items,
         };
     }
@@ -1511,6 +1559,10 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     public IEnumerable<Song> GetRandomSongs(int count) => _catalog.GetRandomSongs(count);
     public (IEnumerable<Artist> artists, IEnumerable<Album> albums, IEnumerable<Song> songs) SearchAll(string query) => _catalog.SearchAll(query);
     public CoverArtData? GetCoverArt(string? id) => _catalog.GetCoverArt(id);
+
+    private static bool HasMissingCoreMetadata(SerializableSong song) => song.Duration <= TimeSpan.Zero;
+    private static bool HasMissingCoreMetadata(Song song) => song.Duration <= 0;
+
     private static DateTime TruncateMilliseconds(DateTime dt)
     {
         return new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, dt.Kind);

--- a/Meziantou.MusicApp.WebPlayer/README.md
+++ b/Meziantou.MusicApp.WebPlayer/README.md
@@ -14,7 +14,7 @@ The features
 - AirPlay: Stream audio to AirPlay devices on Safari/macOS
 - Media Session API: System-level media controls and notifications
 - Dark Theme: Easy on the eyes
-- Read-only server interaction (except manual library rescan)
+- Read-only server interaction (except manual and force library rescans)
 - State persistence: Playback state saved in IndexedDB
 - Auto-resume: Continues playback on app reopen
 - Background sync: Periodic playlist refresh (5 min intervals)

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -32,7 +32,7 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
 
   const [formData, setFormData] = useState<AppSettings>(settings);
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
-  const [scanStatus, setScanStatus] = useState<'idle' | 'scanning'>('idle');
+  const [scanStatus, setScanStatus] = useState<'idle' | 'scanning' | 'force-scanning'>('idle');
   const settingsRef = useRef(settings);
   const prevIsOpenRef = useRef(isOpen);
 
@@ -71,6 +71,15 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
     setScanStatus('scanning');
     try {
       await triggerLibraryScan();
+    } finally {
+      setScanStatus('idle');
+    }
+  };
+
+  const handleForceRescanLibrary = async () => {
+    setScanStatus('force-scanning');
+    try {
+      await triggerLibraryScan(true);
     } finally {
       setScanStatus('idle');
     }
@@ -261,10 +270,20 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
                 <button
                   className="secondary-button"
                   onClick={handleRescanLibrary}
-                  disabled={scanStatus === 'scanning'}
+                  disabled={scanStatus !== 'idle'}
                   style={{ width: '100%', marginBottom: '8px' }}
                 >
                   {scanStatus === 'scanning' ? 'Scanning...' : 'Rescan Music Library'}
+                </button>
+              </div>
+              <div className="form-group">
+                <button
+                  className="secondary-button"
+                  onClick={handleForceRescanLibrary}
+                  disabled={scanStatus !== 'idle'}
+                  style={{ width: '100%', marginBottom: '8px' }}
+                >
+                  {scanStatus === 'force-scanning' ? 'Force Scanning...' : 'Force Rescan (Ignore Cache)'}
                 </button>
               </div>
               <div className="form-group">

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -68,7 +68,7 @@ interface AppContextValue {
   playingPlaylistId: string | null;
 
   // Library scan
-  triggerLibraryScan: () => Promise<void>;
+  triggerLibraryScan: (force?: boolean) => Promise<void>;
 }
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -810,7 +810,7 @@ export function AppProvider({ children }: AppProviderProps) {
     }
   }, [settings]);
 
-  const triggerLibraryScan = useCallback(async () => {
+  const triggerLibraryScan = useCallback(async (force = false) => {
     if (!isOnline) {
       showToast('Cannot trigger scan while offline', 'error');
       return;
@@ -823,8 +823,8 @@ export function AppProvider({ children }: AppProviderProps) {
 
     try {
       const api = getApiService();
-      await api.triggerScan();
-      showToast('Library scan started', 'success');
+      await api.triggerScan(force);
+      showToast(force ? 'Force library scan started' : 'Library scan started', 'success');
 
       // Check for invalid playlists after a short delay to allow scan to complete
       setTimeout(async () => {
@@ -839,7 +839,7 @@ export function AppProvider({ children }: AppProviderProps) {
       }, 3000);
     } catch (error) {
       console.error('Failed to trigger library scan:', error);
-      showToast('Failed to trigger library scan', 'error');
+      showToast(force ? 'Failed to trigger force library scan' : 'Failed to trigger library scan', 'error');
     }
   }, [isOnline, settings.serverUrl, showToast]);
 

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
@@ -1,12 +1,41 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { ApiService } from './api-service';
 
 describe('ApiService', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('getCoverHeaders prefers modern image formats', () => {
     const service = new ApiService('https://example.com');
 
     expect(service.getCoverHeaders()).toEqual({
       Accept: 'image/avif,image/webp,image/png,image/jpeg;q=0.8,*/*;q=0.5'
     });
+  });
+
+  it('triggerScan adds force query when requested', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        isScanning: false,
+        isInitialScanCompleted: true,
+        scanCount: 0,
+        lastScanDate: null,
+        percentage: null,
+        estimatedCompletionTime: null,
+        invalidPlaylists: [],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new ApiService('https://example.com');
+    await service.triggerScan(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/api/scan.json?force=true',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 });

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
@@ -54,8 +54,9 @@ export class ApiService {
     return this.fetch<ScanStatusResponse>('/api/scan/status.json');
   }
 
-  async triggerScan(): Promise<ScanStatusResponse> {
-    return this.fetch<ScanStatusResponse>('/api/scan.json', { method: 'POST' });
+  async triggerScan(force = false): Promise<ScanStatusResponse> {
+    const query = force ? '?force=true' : '';
+    return this.fetch<ScanStatusResponse>(`/api/scan.json${query}`, { method: 'POST' });
   }
 
   getSongStreamUrl(songId: string, quality: StreamingQuality): string {


### PR DESCRIPTION
## Why

The scan cache keeps library refreshes fast, but it can keep stale track metadata forever when core fields are missing. After media tag library improvements, tracks with missing duration (for example `Duration == 0`) should be re-read instead of reused from cache. The web player also needed an explicit way to run a full no-cache rescan.

## What changed

- Updated server scan logic to bypass cache reuse for unchanged files when cached core metadata is incomplete (`Duration <= 0`).
- Populate `SerializableSong.Duration` from media tags during file scans.
- Added a new virtual playlist: `virtual:needs-rescan` (`⚠️ Needs Rescan`) that lists tracks with missing core metadata.
- Added force scan support end-to-end:
  - `MusicLibraryService.ScanMusicLibrary(bool force = false)`
  - `POST /api/scan.json?force=true`
  - Web player API + hook wiring for `force`
  - New **Force Rescan (Ignore Cache)** button in Settings > Advanced (while keeping the existing normal rescan button).
- Updated tests for the new behavior in server unit/integration tests and web player API service tests.

## Validation

- `dotnet test --nologo`
- `cd Meziantou.MusicApp.WebPlayer && npm test && npm run build`