### PR TITLE
Optimize WebPlayer render updates and background timers

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
@@ -53,6 +53,7 @@ export function CoverImage({
   const [coverSrc, setCoverSrc] = useState(COVER_PLACEHOLDER_DATA_URI);
   const coverBlobUrlRef = useRef<string | null>(null);
   const isTrackCached = cachedTrackIds.has(trackId);
+  const imageLoading = size <= 48 ? 'lazy' : 'eager';
 
   // Always revoke any blob URL on unmount so virtualized rows don't leak
   // when they scroll out of view without re-running the main effect.
@@ -156,6 +157,8 @@ export function CoverImage({
       className={className}
       src={coverSrc}
       alt={alt}
+      loading={imageLoading}
+      decoding="async"
       onClick={onClick}
     />
   );

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import type { RepeatMode } from '../types';
 import { formatDuration } from '../utils';
 import { useApp } from '../hooks';
+import { audioPlayer, type PlayerEventDetail } from '../services';
 import { CoverImage } from './CoverImage';
 
 interface PlayerBarProps {
@@ -23,6 +24,8 @@ const getFormatColor = (format: string) => {
 
 export function PlayerBar({ onQueueClick }: PlayerBarProps) {
   const { playerState, playerActions, currentPlaylistId, selectPlaylist, playlists } = useApp();
+  const [currentTime, setCurrentTime] = useState(() => audioPlayer.getCurrentTime());
+  const [duration, setDuration] = useState(() => audioPlayer.getDuration());
 
   const [isDragging, setIsDragging] = useState(false);
   const [showRemainingTime, setShowRemainingTime] = useState(() => {
@@ -42,9 +45,10 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
 
     const rect = bar.getBoundingClientRect();
     const percent = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-    const time = percent * playerState.duration;
+    const time = percent * duration;
+    setCurrentTime(time);
     playerActions.seek(time);
-  }, [playerState.duration, playerActions]);
+  }, [duration, playerActions]);
 
   const handleProgressMouseDown = (e: React.MouseEvent) => {
     setIsDragging(true);
@@ -74,6 +78,40 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
       if (volumePopoverTimeoutRef.current) {
         window.clearTimeout(volumePopoverTimeoutRef.current);
       }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleTimeUpdate = (detail: PlayerEventDetail) => {
+      if (typeof detail.currentTime === 'number') {
+        setCurrentTime(detail.currentTime);
+      }
+      if (typeof detail.duration === 'number' && Number.isFinite(detail.duration)) {
+        setDuration(detail.duration);
+      }
+    };
+
+    const handleDurationChange = (detail: PlayerEventDetail) => {
+      if (typeof detail.duration === 'number' && Number.isFinite(detail.duration)) {
+        setDuration(detail.duration);
+      } else {
+        setDuration(audioPlayer.getDuration());
+      }
+    };
+
+    const handleTrackChange = () => {
+      setCurrentTime(0);
+      setDuration(audioPlayer.getDuration());
+    };
+
+    audioPlayer.on('timeupdate', handleTimeUpdate);
+    audioPlayer.on('durationchange', handleDurationChange);
+    audioPlayer.on('trackchange', handleTrackChange);
+
+    return () => {
+      audioPlayer.off('timeupdate', handleTimeUpdate);
+      audioPlayer.off('durationchange', handleDurationChange);
+      audioPlayer.off('trackchange', handleTrackChange);
     };
   }, []);
 
@@ -123,8 +161,15 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
     window.dispatchEvent(new CustomEvent('scrollToCurrentTrack'));
   };
 
-  const progressPercent = playerState.duration > 0
-    ? (playerState.currentTime / playerState.duration) * 100
+  useEffect(() => {
+    if (!playerState.currentTrack) {
+      setCurrentTime(0);
+      setDuration(0);
+    }
+  }, [playerState.currentTrack]);
+
+  const progressPercent = duration > 0
+    ? (currentTime / duration) * 100
     : 0;
 
   return (
@@ -205,7 +250,7 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
 
         <div className="player-progress">
           <span className="progress-time current-time">
-            {formatDuration(playerState.currentTime)}
+            {formatDuration(currentTime)}
           </span>
           <div
             className="progress-bar-container"
@@ -229,9 +274,9 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
             style={{ cursor: 'pointer' }}
             title={showRemainingTime ? 'Show total time' : 'Show remaining time'}
           >
-            {showRemainingTime && playerState.duration > 0
-              ? `-${formatDuration(playerState.duration - playerState.currentTime)}`
-              : formatDuration(playerState.duration)}
+            {showRemainingTime && duration > 0
+              ? `-${formatDuration(duration - currentTime)}`
+              : formatDuration(duration)}
           </span>
         </div>
       </div>

--- a/Meziantou.MusicApp.WebPlayer/src/components/QueuePanel.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/QueuePanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { QueueItem } from '../types';
 import { useApp } from '../hooks';
 import { PlayingIndicator } from './PlayingIndicator';
@@ -7,18 +8,35 @@ interface QueuePanelProps {
   onClose: () => void;
 }
 
+interface IndexedQueueItem {
+  item: QueueItem;
+  lookaheadIndex: number;
+}
+
 export function QueuePanel({ isOpen, onClose }: QueuePanelProps) {
   const { playerState, playerActions, playlists } = useApp();
+  const lookaheadQueue = playerState.lookaheadQueue;
+  const currentTrack = playerState.currentTrack;
+  const { manualItems, playlistItems } = useMemo(() => {
+    const manual: IndexedQueueItem[] = [];
+    const playlist: IndexedQueueItem[] = [];
+
+    for (let i = 0; i < lookaheadQueue.length; i++) {
+      const indexedItem = { item: lookaheadQueue[i], lookaheadIndex: i };
+      if (indexedItem.item.source === 'manual') {
+        manual.push(indexedItem);
+      } else if (indexedItem.item.source === 'playlist') {
+        playlist.push(indexedItem);
+      }
+    }
+
+    return { manualItems: manual, playlistItems: playlist };
+  }, [lookaheadQueue]);
 
   if (!isOpen) return null;
 
-  const lookaheadQueue = playerState.lookaheadQueue;
-  const currentTrack = playerState.currentTrack;
-  const manualItems = lookaheadQueue.filter(item => item.source === 'manual');
-  const playlistItems = lookaheadQueue.filter(item => item.source === 'playlist');
-
   const playlistName = playlistItems.length > 0
-    ? playlists.find(p => p.id === playlistItems[0].playlistId)?.name || 'Playlist'
+    ? playlists.find(p => p.id === playlistItems[0].item.playlistId)?.name || 'Playlist'
     : 'Playlist';
 
   const handleRemoveItem = (lookaheadIndex: number) => {
@@ -78,7 +96,6 @@ export function QueuePanel({ isOpen, onClose }: QueuePanelProps) {
               <QueueSection
                 title="Next Up"
                 items={manualItems}
-                lookaheadQueue={lookaheadQueue}
                 startNumber={1}
                 onPlay={handlePlayItem}
                 onRemove={handleRemoveItem}
@@ -88,7 +105,6 @@ export function QueuePanel({ isOpen, onClose }: QueuePanelProps) {
               <QueueSection
                 title={`Next from: ${playlistName}`}
                 items={playlistItems}
-                lookaheadQueue={lookaheadQueue}
                 startNumber={manualItems.length + 1}
                 onPlay={handlePlayItem}
                 onRemove={handleRemoveItem}
@@ -103,19 +119,18 @@ export function QueuePanel({ isOpen, onClose }: QueuePanelProps) {
 
 interface QueueSectionProps {
   title: string;
-  items: QueueItem[];
-  lookaheadQueue: QueueItem[];
+  items: IndexedQueueItem[];
   startNumber: number;
   onPlay: (lookaheadIndex: number) => void;
   onRemove: (lookaheadIndex: number) => void;
 }
 
-function QueueSection({ title, items, lookaheadQueue, startNumber, onPlay, onRemove }: QueueSectionProps) {
+function QueueSection({ title, items, startNumber, onPlay, onRemove }: QueueSectionProps) {
   return (
     <div className="queue-section">
       <div className="queue-section-header">{title}</div>
-      {items.map((item, i) => {
-        const lookaheadIndex = lookaheadQueue.indexOf(item);
+      {items.map((indexedItem, i) => {
+        const { item, lookaheadIndex } = indexedItem;
         const displayNumber = startNumber + i;
 
         return (

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useMemo, type ReactNode } from 'react';
 import type {
   AppSettings,
   PlaylistSummary,
@@ -950,7 +950,7 @@ export function AppProvider({ children }: AppProviderProps) {
     showToast('Removed offline playlist');
   }, [playlists, showToast]);
 
-  const value: AppContextValue = {
+  const value = useMemo<AppContextValue>(() => ({
     settings,
     updateSettings,
     playlists,
@@ -982,7 +982,39 @@ export function AppProvider({ children }: AppProviderProps) {
     testConnection,
     playingPlaylistId,
     triggerLibraryScan,
-  };
+  }), [
+    settings,
+    updateSettings,
+    playlists,
+    currentPlaylistId,
+    currentPlaylistTracks,
+    selectPlaylist,
+    syncPlaylists,
+    createPlaylist,
+    deletePlaylist,
+    invalidPlaylists,
+    isOnline,
+    networkType,
+    cachedTrackIds,
+    downloadTrack,
+    deleteDownloadedTrack,
+    clearAllCachedTracks,
+    offlinePlaylistIds,
+    playlistDownloadProgress,
+    startPlaylistCaching,
+    stopPlaylistCaching,
+    playerState,
+    playerActions,
+    isLoading,
+    isInitialized,
+    showToast,
+    playTrack,
+    addTrackToPlaylist,
+    removeTrackFromPlaylist,
+    testConnection,
+    playingPlaylistId,
+    triggerLibraryScan,
+  ]);
 
   return (
     <AppContext.Provider value={value}>

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import type { TrackInfo, RepeatMode, QueueItem, StreamingQuality, ReplayGainMode, PlaybackState } from '../types';
 import { audioPlayer, type PlayerEventType, type PlayerEventDetail } from '../services';
 
@@ -6,7 +6,6 @@ export interface AudioPlayerState {
   currentTrack: TrackInfo | null;
   currentQuality: StreamingQuality | null;
   isPlaying: boolean;
-  currentTime: number;
   duration: number;
   volume: number;
   isMuted: boolean;
@@ -56,7 +55,6 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
     currentTrack: audioPlayer.getCurrentTrack(),
     currentQuality: audioPlayer.getCurrentQuality(),
     isPlaying: audioPlayer.isPlaying(),
-    currentTime: audioPlayer.getCurrentTime(),
     duration: audioPlayer.getDuration(),
     volume: audioPlayer.getVolume(),
     isMuted: audioPlayer.getIsMuted(),
@@ -70,8 +68,6 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
     isAirPlayActive: audioPlayer.isAirPlayActive(),
   });
 
-  const timeUpdateThrottleRef = useRef<number>(0);
-
   useEffect(() => {
     const handlers: { event: PlayerEventType; handler: (detail: PlayerEventDetail) => void }[] = [
       {
@@ -81,20 +77,6 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
       {
         event: 'pause',
         handler: () => setState(prev => ({ ...prev, isPlaying: false })),
-      },
-      {
-        event: 'timeupdate',
-        handler: (detail) => {
-          const now = Date.now();
-          if (now - timeUpdateThrottleRef.current > 250) {
-            timeUpdateThrottleRef.current = now;
-            setState(prev => ({
-              ...prev,
-              currentTime: detail.currentTime ?? prev.currentTime,
-              duration: detail.duration ?? prev.duration,
-            }));
-          }
-        },
       },
       {
         event: 'durationchange',

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useServiceWorkerUpdate.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useServiceWorkerUpdate.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
 interface ServiceWorkerUpdateState {
@@ -7,6 +8,17 @@ interface ServiceWorkerUpdateState {
 }
 
 export function useServiceWorkerUpdate(): ServiceWorkerUpdateState {
+  const updateIntervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (updateIntervalRef.current !== null) {
+        window.clearInterval(updateIntervalRef.current);
+        updateIntervalRef.current = null;
+      }
+    };
+  }, []);
+
   const {
     needRefresh: [needRefresh],
     offlineReady: [offlineReady],
@@ -17,7 +29,14 @@ export function useServiceWorkerUpdate(): ServiceWorkerUpdateState {
 
       // Check for updates periodically (every hour)
       if (registration) {
-        setInterval(() => {
+        if (updateIntervalRef.current !== null) {
+          window.clearInterval(updateIntervalRef.current);
+        }
+
+        updateIntervalRef.current = window.setInterval(() => {
+          if (!navigator.onLine || document.hidden) {
+            return;
+          }
           registration.update();
         }, 60 * 60 * 1000);
       }


### PR DESCRIPTION
## Why

Playback progress updates were flowing through shared app state and forcing broad rerenders across the WebPlayer. Combined with repeated queue derivation and background timer activity, this increased CPU/battery usage and memory churn, especially with larger libraries.

## What changed

- Removed playback `timeupdate` handling from `useAudioPlayer` shared React state to stop high-frequency global state churn.
- Added local playback clock state in `PlayerBar` by subscribing directly to audio player events (`timeupdate`, `durationchange`, `trackchange`).
- Memoized the `useApp` context value to reduce unnecessary rerenders in unrelated consumers.
- Optimized `QueuePanel` lookahead processing to a single pass with precomputed indexes instead of repeated `filter` + `indexOf` work.
- Improved cover image loading hints in `CoverImage` (`loading` and `decoding`) to reduce decode pressure.
- Updated service worker polling lifecycle to clear intervals and skip update checks when offline or hidden.

## Notes and tradeoffs

- Playback time is now intentionally localized to `PlayerBar`; global consumers should subscribe explicitly if needed.
- Cover images may appear slightly later during fast scrolling due to lazy/async loading hints.
- Service worker update checks can be delayed while the tab is hidden or offline, in exchange for lower background wakeups.

## Validation

- `dotnet test`
- `cd Meziantou.MusicApp.WebPlayer && npm run build`
- `cd Meziantou.MusicApp.WebPlayer && npm test`
- `cd Meziantou.MusicApp.WebPlayer && npm run lint` currently fails because `eslint` is not available in project dependencies in this environment.