### PR TITLE
Use perceptual volume curve (-10 dB per halving)

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/package-lock.json
+++ b/Meziantou.MusicApp.WebPlayer/package-lock.json
@@ -2575,9 +2575,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2595,9 +2592,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2615,9 +2609,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2635,9 +2626,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2655,9 +2643,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2675,9 +2660,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
@@ -230,8 +230,11 @@ describe('AudioPlayerService Queue Logic', () => {
     it('should reset media element volume when AudioContext is initialized', async () => {
       player.setVolume(0.3);
 
+      // Perceptual curve: amplitude = volume ^ (log2(10) / 2)
+      const expectedAmplitude = Math.pow(0.3, Math.log2(10) / 2);
+
       const audioBeforePlay = (player as any).audioInstance.audio as HTMLAudioElement;
-      expect(audioBeforePlay.volume).toBeCloseTo(0.09, 5);
+      expect(audioBeforePlay.volume).toBeCloseTo(expectedAmplitude, 5);
 
       await player.play();
 
@@ -239,7 +242,7 @@ describe('AudioPlayerService Queue Logic', () => {
       expect(audioAfterPlay.volume).toBe(1);
 
       const gainNode = (player as any).masterGainNode as GainNode;
-      expect(gainNode.gain.value).toBeCloseTo(0.09, 5);
+      expect(gainNode.gain.value).toBeCloseTo(expectedAmplitude, 5);
     });
 
     it('should keep media element unmuted when using gain-node muting', async () => {

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -866,14 +866,16 @@ export class AudioPlayerService {
     this.updatePositionState();
   }
 
-  private linearToLogarithmic(linear: number): number {
-    // Convert linear slider value (0-2) to logarithmic gain value
-    // Using exponential curve: gain = linear^2 for smoother control at lower volumes
-    return linear * linear;
+  private linearToPerceptual(volume: number): number {
+    // Map slider value to amplitude using a -10 dB per halving curve so the
+    // slider percentage matches perceived loudness:
+    //   100% -> 1.0 (0 dB), 50% -> ~0.316 (-10 dB), 25% -> ~0.1 (-20 dB), 200% -> ~3.16 (+10 dB).
+    if (volume <= 0) return 0;
+    return Math.pow(volume, Math.log2(10) / 2);
   }
 
   private applyOutputVolume(): void {
-    const gainValue = this.linearToLogarithmic(this.masterVolume);
+    const gainValue = this.linearToPerceptual(this.masterVolume);
 
     if (this.masterGainNode) {
       // Keep the media element at full volume when using Web Audio gain to avoid compounding attenuation.


### PR DESCRIPTION
The previous `linear²` volume curve did not align with how humans perceive loudness. At 50% slider the gain dropped to only 0.25 (-12 dB), but it felt much quieter than "half as loud", which perceptually corresponds to about -10 dB.

This PR replaces the curve with `volume ^ (log2(10) / 2)`, which maps the slider so that each halving of the percentage equals a -10 dB reduction in amplitude:

| Slider | Old gain (linear²) | New amplitude (perceptual) | dB |
|--------|-------------------|----------------------------|----|
| 200%   | 4.0               | ~3.16                      | +10 dB |
| 100%   | 1.0               | 1.0                        | 0 dB |
| 50%    | 0.25              | ~0.316                     | -10 dB |
| 25%    | 0.0625            | ~0.1                       | -20 dB |

The method is also renamed from `linearToLogarithmic` to `linearToPerceptual` to better describe its intent. Tests are updated to derive the expected amplitude from the same formula rather than a hardcoded value, so they stay correct if the curve is ever tweaked again.