### PR TITLE
Reduce background CPU and memory usage in web player

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/App.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { AppProvider, useApp } from './hooks';
+import { AppProvider, useApp, usePlayer } from './hooks';
 import { audioPlayer } from './services';
 import type { TrackInfo } from './types';
 import {
@@ -17,7 +17,8 @@ import './styles/main.css';
 const VOLUME_STEP = 0.05;
 
 function AppContent() {
-  const { isLoading, settings, isInitialized, playerActions } = useApp();
+  const { isLoading, settings, isInitialized } = useApp();
+  const { playerActions } = usePlayer();
   const [queueOpen, setQueueOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { RepeatMode } from '../types';
 import { formatDuration } from '../utils';
-import { useApp } from '../hooks';
+import { useApp, usePlayer } from '../hooks';
 import { audioPlayer, type PlayerEventDetail } from '../services';
 import { CoverImage } from './CoverImage';
 
@@ -23,7 +23,8 @@ const getFormatColor = (format: string) => {
 };
 
 export function PlayerBar({ onQueueClick }: PlayerBarProps) {
-  const { playerState, playerActions, currentPlaylistId, selectPlaylist, playlists } = useApp();
+  const { currentPlaylistId, selectPlaylist, playlists } = useApp();
+  const { playerState, playerActions } = usePlayer();
   const [currentTime, setCurrentTime] = useState(() => audioPlayer.getCurrentTime());
   const [duration, setDuration] = useState(() => audioPlayer.getDuration());
 
@@ -72,11 +73,17 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
 
   const [isVolumePopoverVisible, setIsVolumePopoverVisible] = useState(false);
   const volumePopoverTimeoutRef = useRef<number | undefined>(undefined);
+  const volumeRafRef = useRef<number | null>(null);
+  const pendingVolumeRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
       if (volumePopoverTimeoutRef.current) {
         window.clearTimeout(volumePopoverTimeoutRef.current);
+      }
+      if (volumeRafRef.current !== null) {
+        window.cancelAnimationFrame(volumeRafRef.current);
+        volumeRafRef.current = null;
       }
     };
   }, []);
@@ -137,12 +144,23 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
     showVolumePopover();
   };
 
-  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const volume = parseInt(e.target.value, 10) / 100;
+  const flushPendingVolume = useCallback(() => {
+    volumeRafRef.current = null;
+    const volume = pendingVolumeRef.current;
+    pendingVolumeRef.current = null;
+    if (volume === null) return;
     if (playerState.isMuted && volume > 0) {
       playerActions.toggleMute();
     }
     playerActions.setVolume(volume);
+  }, [playerActions, playerState.isMuted]);
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const volume = parseInt(e.target.value, 10) / 100;
+    pendingVolumeRef.current = volume;
+    if (volumeRafRef.current === null) {
+      volumeRafRef.current = window.requestAnimationFrame(flushPendingVolume);
+    }
     showVolumePopover();
   };
 

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayingIndicator.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayingIndicator.tsx
@@ -1,3 +1,5 @@
+import { useApp } from '../hooks';
+
 interface PlayingIndicatorProps {
   isPlaying: boolean;
   isPaused: boolean;
@@ -5,29 +7,28 @@ interface PlayingIndicatorProps {
 }
 
 export function PlayingIndicator({ isPlaying, isPaused, onTogglePlay }: PlayingIndicatorProps) {
+  const { settings } = useApp();
   return (
     <>
-      {(
-        <button
-          className="track-play-pause-btn"
-          onClick={(e) => {
-            e.stopPropagation();
-            onTogglePlay?.();
-          }}
-          aria-label={isPlaying && !isPaused ? "Pause" : "Play"}
-        >
-          {isPlaying && !isPaused ? (
-            <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
-              <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
-            </svg>
-          ) : (
-            <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
-              <path d="M8 5v14l11-7z" />
-            </svg>
-          )}
-        </button>
-      )}
-      {isPlaying && (
+      <button
+        className="track-play-pause-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          onTogglePlay?.();
+        }}
+        aria-label={isPlaying && !isPaused ? "Pause" : "Play"}
+      >
+        {isPlaying && !isPaused ? (
+          <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
+            <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        )}
+      </button>
+      {isPlaying && !settings.disablePlayingAnimation && (
         <div className={`playing-animation ${isPaused ? 'paused' : ''}`}>
           <span></span><span></span><span></span>
         </div>

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlaylistSidebar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlaylistSidebar.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { PlaylistSummary } from '../types';
 import { formatDuration } from '../utils';
-import { useApp } from '../hooks';
+import { useApp, usePlayer } from '../hooks';
 
 interface PlaylistSidebarProps {
   onSettingsClick: () => void;
@@ -11,7 +11,6 @@ export function PlaylistSidebar({ onSettingsClick }: PlaylistSidebarProps) {
   const {
     playlists,
     currentPlaylistId,
-    playingPlaylistId,
     selectPlaylist,
     offlinePlaylistIds,
     playlistDownloadProgress,
@@ -21,6 +20,7 @@ export function PlaylistSidebar({ onSettingsClick }: PlaylistSidebarProps) {
     networkType,
     invalidPlaylists,
   } = useApp();
+  const { playingPlaylistId } = usePlayer();
 
   return (
     <aside className="sidebar">

--- a/Meziantou.MusicApp.WebPlayer/src/components/QueuePanel.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/QueuePanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { QueueItem } from '../types';
-import { useApp } from '../hooks';
+import { useApp, usePlayer } from '../hooks';
 import { PlayingIndicator } from './PlayingIndicator';
 
 interface QueuePanelProps {
@@ -14,7 +14,8 @@ interface IndexedQueueItem {
 }
 
 export function QueuePanel({ isOpen, onClose }: QueuePanelProps) {
-  const { playerState, playerActions, playlists } = useApp();
+  const { playlists } = useApp();
+  const { playerState, playerActions } = usePlayer();
   const lookaheadQueue = playerState.lookaheadQueue;
   const currentTrack = playerState.currentTrack;
   const { manualItems, playlistItems } = useMemo(() => {

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import type { AppSettings, StreamingQuality, ReplayGainMode } from '../types';
 import { DEFAULT_SETTINGS } from '../constants';
-import { useApp } from '../hooks';
+import { useApp, useServiceWorkerUpdate } from '../hooks';
 
 const QUALITY_OPTIONS: { label: string; value: StreamingQuality }[] = [
   { label: 'Original (Raw)', value: { format: 'raw' } },
@@ -28,11 +28,13 @@ interface SettingsDialogProps {
 }
 
 export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsDialogProps) {
-  const { settings, updateSettings, testConnection, triggerLibraryScan } = useApp();
+  const { settings, updateSettings, testConnection, triggerLibraryScan, isOnline } = useApp();
+  const { checkForUpdate, needRefresh, updateServiceWorker } = useServiceWorkerUpdate();
 
   const [formData, setFormData] = useState<AppSettings>(settings);
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [scanStatus, setScanStatus] = useState<'idle' | 'scanning' | 'force-scanning'>('idle');
+  const [updateStatus, setUpdateStatus] = useState<'idle' | 'checking' | 'up-to-date' | 'error'>('idle');
   const settingsRef = useRef(settings);
   const prevIsOpenRef = useRef(isOpen);
 
@@ -83,6 +85,20 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
     } finally {
       setScanStatus('idle');
     }
+  };
+
+  const handleCheckForUpdate = async () => {
+    setUpdateStatus('checking');
+    try {
+      const ok = await checkForUpdate();
+      setUpdateStatus(ok ? 'up-to-date' : 'error');
+    } catch {
+      setUpdateStatus('error');
+    }
+  };
+
+  const handleApplyUpdate = () => {
+    updateServiceWorker(true);
   };
 
   const handleSave = async () => {
@@ -250,6 +266,18 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
               </label>
               <small>Hide the offline availability icon in the track list</small>
             </div>
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  id="disable-playing-animation"
+                  checked={formData.disablePlayingAnimation}
+                  onChange={(e) => handleInputChange('disablePlayingAnimation', e.target.checked)}
+                />
+                Disable Playing Track Animation
+              </label>
+              <small>Hide the animated bars that indicate the currently playing track. Reduces background CPU.</small>
+            </div>
           </section>
 
           <section className="settings-section">
@@ -296,6 +324,36 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
                 Show ReplayGain Warning
               </label>
               <small>Show an indicator when a track is missing ReplayGain data</small>
+            </div>
+          </section>
+
+          <section className="settings-section">
+            <h3>Updates</h3>
+            <div className="form-group">
+              <button
+                className="secondary-button"
+                onClick={handleCheckForUpdate}
+                disabled={updateStatus === 'checking' || !isOnline}
+                style={{ width: '100%', marginBottom: '8px' }}
+              >
+                {updateStatus === 'checking' ? 'Checking…' : 'Check for Updates'}
+              </button>
+              <small>
+                {!isOnline && 'Offline — connect to check for updates.'}
+                {isOnline && updateStatus === 'idle' && 'The app checks automatically every hour while visible.'}
+                {isOnline && updateStatus === 'up-to-date' && !needRefresh && '✓ App is up to date.'}
+                {isOnline && updateStatus === 'error' && '✗ Update check failed.'}
+                {needRefresh && 'A new version is available.'}
+              </small>
+              {needRefresh && (
+                <button
+                  className="primary-button"
+                  onClick={handleApplyUpdate}
+                  style={{ width: '100%', marginTop: '8px' }}
+                >
+                  Reload to Apply Update
+                </button>
+              )}
             </div>
           </section>
 

--- a/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/TrackList.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import type { TrackInfo, AppSettings } from '../types';
 import { formatDuration, normalizeSearch, debounce, sortTracks } from '../utils';
-import { useApp } from '../hooks';
+import { useApp, usePlayer } from '../hooks';
 import { getApiService } from '../services';
 import { PlayingIndicator } from './PlayingIndicator';
 import { CoverImage } from './CoverImage';
@@ -33,16 +33,14 @@ export function TrackList() {
     settings,
     currentPlaylistTracks,
     currentPlaylistId,
-    playingPlaylistId,
-    playerState,
     cachedTrackIds,
     isOnline,
     playTrack,
     downloadTrack,
     deleteDownloadedTrack,
-    playerActions,
     showToast,
   } = useApp();
+  const { playerState, playerActions, playingPlaylistId } = usePlayer();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [visibleRange, setVisibleRange] = useState({ start: 0, end: 20 });
@@ -63,10 +61,12 @@ export function TrackList() {
     [currentPlaylistTracks, sortDirection, sortOption]
   );
 
-  // Precomputed normalized search text per sorted track. Built once per
-  // playlist/sort so each keystroke is a cheap string.includes scan instead
-  // of re-normalizing every searchable field on every track.
+  // Precomputed normalized search text per sorted track. Only built when the
+  // user actually starts searching — for backgrounded sessions on huge
+  // playlists this avoids holding several MB of normalized strings in RAM
+  // that nobody is going to read.
   const searchHaystacks = useMemo(() => {
+    if (!searchQuery) return null;
     const out = new Array<string>(sortedTracks.length);
     for (let i = 0; i < sortedTracks.length; i++) {
       const t = sortedTracks[i];
@@ -75,10 +75,10 @@ export function TrackList() {
       );
     }
     return out;
-  }, [sortedTracks]);
+  }, [sortedTracks, searchQuery]);
 
   const filteredTracks = useMemo(() => {
-    if (!searchQuery) {
+    if (!searchQuery || !searchHaystacks) {
       return sortedTracks;
     }
 

--- a/Meziantou.MusicApp.WebPlayer/src/constants.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   hideTrackIndex: false,
   hideTrackDuration: false,
   hideTrackCacheStatus: false,
+  disablePlayingAnimation: false,
   replayGainMode: 'off',
   replayGainPreamp: 0,
   showReplayGainWarning: true

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/index.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useAudioPlayer } from './useAudioPlayer';
 export { AppProvider, useApp } from './useApp';
+export { usePlayer, PlayerProvider } from './usePlayer';
 export { useServiceWorkerUpdate } from './useServiceWorkerUpdate';

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -10,11 +10,10 @@ import {
   initApiService,
   getApiService,
   storageService,
-  audioPlayer,
   downloadService,
 } from '../services';
 import { getNetworkType } from '../utils';
-import { useAudioPlayer, type AudioPlayerState, type AudioPlayerActions } from './useAudioPlayer';
+import { PlayerProvider, usePlayer } from './usePlayer';
 
 interface AppContextValue {
   // Settings
@@ -47,10 +46,6 @@ interface AppContextValue {
   startPlaylistCaching: (playlistId: string) => Promise<void>;
   stopPlaylistCaching: (playlistId: string) => Promise<void>;
 
-  // Audio player
-  playerState: AudioPlayerState;
-  playerActions: AudioPlayerActions;
-
   // UI state
   isLoading: boolean;
   isInitialized: boolean;
@@ -63,9 +58,6 @@ interface AppContextValue {
 
   // Test connection
   testConnection: () => Promise<boolean>;
-
-  // Playing state
-  playingPlaylistId: string | null;
 
   // Library scan
   triggerLibraryScan: (force?: boolean) => Promise<void>;
@@ -84,6 +76,14 @@ interface AppProviderProps {
 }
 
 export function AppProvider({ children }: AppProviderProps) {
+  return (
+    <PlayerProvider>
+      <AppDataProvider>{children}</AppDataProvider>
+    </PlayerProvider>
+  );
+}
+
+function AppDataProvider({ children }: AppProviderProps) {
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const [playlists, setPlaylists] = useState<PlaylistSummary[]>([]);
   const [currentPlaylistId, setCurrentPlaylistId] = useState<string | null>(null);
@@ -104,9 +104,8 @@ export function AppProvider({ children }: AppProviderProps) {
   const isLoading = loadingCount > 0;
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
-  const [playingPlaylistId, setPlayingPlaylistId] = useState<string | null>(null);
 
-  const [playerState, playerActions] = useAudioPlayer();
+  const { playerActions } = usePlayer();
 
   const setIsLoading = useCallback((loading: boolean) => {
     setLoadingCount(prev => Math.max(0, prev + (loading ? 1 : -1)));
@@ -270,7 +269,7 @@ export function AppProvider({ children }: AppProviderProps) {
              }
 
              if (tracks.length > 0) {
-                 setPlayingPlaylistId(state.currentPlaylistId);
+                 // playingPlaylistId is derived from queuechange/trackchange in PlayerProvider.
                  playerActions.setPlaylist(state.currentPlaylistId, tracks, state.shuffleOrder);
 
                  // Find the correct track index using the track ID for more reliable restoration
@@ -390,24 +389,26 @@ export function AppProvider({ children }: AppProviderProps) {
     return unsubscribe;
   }, [showToast]);
 
-  // Track change handler - update playing playlist
+  // Refresh playlists when app becomes visible, and reflect visibility on
+  // <html data-hidden> so CSS can pause infinite animations off-screen.
   useEffect(() => {
-    const handler = () => {
-      const playlistId = playerActions.getCurrentPlaylistId();
-      setPlayingPlaylistId(playlistId);
+    const applyHiddenAttr = () => {
+      const root = document.documentElement;
+      if (document.hidden) {
+        root.setAttribute('data-hidden', 'true');
+      } else {
+        root.removeAttribute('data-hidden');
+      }
     };
-    audioPlayer.on('trackchange', handler);
-    return () => audioPlayer.off('trackchange', handler);
-  }, [playerActions]);
 
-  // Refresh playlists when app becomes visible
-  useEffect(() => {
     const handleVisibilityChange = () => {
+      applyHiddenAttr();
       if (!document.hidden && isOnline && settings.serverUrl) {
         syncPlaylistsInternal();
       }
     };
 
+    applyHiddenAttr();
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [isOnline, settings.serverUrl]);
@@ -742,8 +743,8 @@ export function AppProvider({ children }: AppProviderProps) {
     playerActions.setQuality(quality);
 
     playerActions.setPlaylist(currentPlaylistId, tracks || currentPlaylistTracks);
-    setPlayingPlaylistId(currentPlaylistId);
     await playerActions.playTrack(_track);
+    // playingPlaylistId is updated via the trackchange event in PlayerProvider
   }, [currentPlaylistId, currentPlaylistTracks, settings, playerActions]);
 
   const downloadTrack = useCallback(async (track: TrackInfo) => {
@@ -971,8 +972,6 @@ export function AppProvider({ children }: AppProviderProps) {
     playlistDownloadProgress,
     startPlaylistCaching,
     stopPlaylistCaching,
-    playerState,
-    playerActions,
     isLoading,
     isInitialized,
     showToast,
@@ -980,7 +979,6 @@ export function AppProvider({ children }: AppProviderProps) {
     addTrackToPlaylist,
     removeTrackFromPlaylist,
     testConnection,
-    playingPlaylistId,
     triggerLibraryScan,
   }), [
     settings,
@@ -1003,8 +1001,6 @@ export function AppProvider({ children }: AppProviderProps) {
     playlistDownloadProgress,
     startPlaylistCaching,
     stopPlaylistCaching,
-    playerState,
-    playerActions,
     isLoading,
     isInitialized,
     showToast,
@@ -1012,7 +1008,6 @@ export function AppProvider({ children }: AppProviderProps) {
     addTrackToPlaylist,
     removeTrackFromPlaylist,
     testConnection,
-    playingPlaylistId,
     triggerLibraryScan,
   ]);
 

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
@@ -103,11 +103,16 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
       },
       {
         event: 'queuechange',
-        handler: () => setState(prev => ({
-          ...prev,
-          queue: audioPlayer.getQueue(),
-          lookaheadQueue: audioPlayer.getLookaheadQueue()
-        })),
+        handler: () => setState(prev => {
+          const queue = audioPlayer.getQueue();
+          const lookaheadQueue = audioPlayer.getLookaheadQueue();
+          // PlayQueueService returns stable references when nothing changed —
+          // bail out of the setState to skip the AppContext fanout entirely.
+          if (prev.queue === queue && prev.lookaheadQueue === lookaheadQueue) {
+            return prev;
+          }
+          return { ...prev, queue, lookaheadQueue };
+        }),
       },
       {
         event: 'loadstart',

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/usePlayer.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/usePlayer.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { audioPlayer } from '../services';
+import { useAudioPlayer, type AudioPlayerState, type AudioPlayerActions } from './useAudioPlayer';
+
+interface PlayerContextValue {
+  playerState: AudioPlayerState;
+  playerActions: AudioPlayerActions;
+  playingPlaylistId: string | null;
+}
+
+const PlayerContext = createContext<PlayerContextValue | null>(null);
+
+interface PlayerProviderProps {
+  children: ReactNode;
+}
+
+export function PlayerProvider({ children }: PlayerProviderProps) {
+  const [playerState, playerActions] = useAudioPlayer();
+  const [playingPlaylistId, setPlayingPlaylistId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = () => {
+      setPlayingPlaylistId(prev => {
+        const next = audioPlayer.getCurrentPlaylistId();
+        return prev === next ? prev : next;
+      });
+    };
+    // Sync on both trackchange and queuechange so setPlaylist() (without an
+    // immediate playTrack) and explicit play paths both update the indicator.
+    audioPlayer.on('trackchange', handler);
+    audioPlayer.on('queuechange', handler);
+    return () => {
+      audioPlayer.off('trackchange', handler);
+      audioPlayer.off('queuechange', handler);
+    };
+  }, []);
+
+  const value = useMemo<PlayerContextValue>(() => ({
+    playerState,
+    playerActions,
+    playingPlaylistId,
+  }), [playerState, playerActions, playingPlaylistId]);
+
+  return <PlayerContext.Provider value={value}>{children}</PlayerContext.Provider>;
+}
+
+export function usePlayer(): PlayerContextValue {
+  const ctx = useContext(PlayerContext);
+  if (!ctx) {
+    throw new Error('usePlayer must be used within a PlayerProvider');
+  }
+  return ctx;
+}

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useServiceWorkerUpdate.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useServiceWorkerUpdate.ts
@@ -1,24 +1,28 @@
-import { useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
 interface ServiceWorkerUpdateState {
   needRefresh: boolean;
   updateServiceWorker: (reloadPage?: boolean) => Promise<void>;
   offlineReady: boolean;
+  checkForUpdate: () => Promise<boolean>;
+}
+
+// Module-level so that multiple hook consumers share the registration and
+// the auto-update interval is set up exactly once for the lifetime of the page.
+let sharedRegistration: ServiceWorkerRegistration | null = null;
+let intervalHandle: number | null = null;
+
+function ensureAutoUpdateInterval(registration: ServiceWorkerRegistration): void {
+  sharedRegistration = registration;
+  if (intervalHandle !== null) return;
+  intervalHandle = window.setInterval(() => {
+    if (!navigator.onLine || document.hidden) return;
+    registration.update();
+  }, 60 * 60 * 1000);
 }
 
 export function useServiceWorkerUpdate(): ServiceWorkerUpdateState {
-  const updateIntervalRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (updateIntervalRef.current !== null) {
-        window.clearInterval(updateIntervalRef.current);
-        updateIntervalRef.current = null;
-      }
-    };
-  }, []);
-
   const {
     needRefresh: [needRefresh],
     offlineReady: [offlineReady],
@@ -26,19 +30,8 @@ export function useServiceWorkerUpdate(): ServiceWorkerUpdateState {
   } = useRegisterSW({
     onRegisteredSW(swUrl: string, registration: ServiceWorkerRegistration | undefined) {
       console.log('Service Worker registered:', swUrl);
-
-      // Check for updates periodically (every hour)
       if (registration) {
-        if (updateIntervalRef.current !== null) {
-          window.clearInterval(updateIntervalRef.current);
-        }
-
-        updateIntervalRef.current = window.setInterval(() => {
-          if (!navigator.onLine || document.hidden) {
-            return;
-          }
-          registration.update();
-        }, 60 * 60 * 1000);
+        ensureAutoUpdateInterval(registration);
       }
     },
     onRegisterError(error: Error) {
@@ -46,9 +39,22 @@ export function useServiceWorkerUpdate(): ServiceWorkerUpdateState {
     },
   });
 
+  const checkForUpdate = useCallback(async (): Promise<boolean> => {
+    const registration = sharedRegistration;
+    if (!registration) return false;
+    try {
+      await registration.update();
+      return true;
+    } catch (error) {
+      console.error('Service Worker manual update failed:', error);
+      return false;
+    }
+  }, []);
+
   return {
     needRefresh,
     updateServiceWorker,
     offlineReady,
+    checkForUpdate,
   };
 }

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -78,6 +78,11 @@ export class AudioPlayerService {
   private eventListeners: Map<PlayerEventType, Set<PlayerEventCallback>> = new Map();
   private saveStateDebounced: ReturnType<typeof setTimeout> | null = null;
   private lastSaveTime: number = 0;
+  private static readonly SAVE_INTERVAL_VISIBLE_MS = 5000;
+  private static readonly SAVE_INTERVAL_HIDDEN_MS = 15000;
+  private visibilityListenerAttached: boolean = false;
+  private onVisibilityChange: (() => void) | null = null;
+  private onPageHide: (() => void) | null = null;
 
   // Recently played tracks for filtering out recently heard songs from the queue
   private recentlyPlayedIds: Set<string> = new Set();
@@ -93,6 +98,7 @@ export class AudioPlayerService {
     this.updateAirPlayStateFromAudio(this.audioInstance.audio);
     this.setupAudioEvents(this.audioInstance);
     this.setupMediaSession();
+    this.setupVisibilityHandling();
     this.queueService = new PlayQueueService({
       currentPlaylistId: null,
       playlist: [],
@@ -167,14 +173,24 @@ export class AudioPlayerService {
     audio.addEventListener('pause', () => {
       this.scheduleIdleRelease();
       this.emit('pause', {});
+      // Force-flush so the latest position is durable when the user pauses,
+      // even if the throttle window has not elapsed yet.
+      this.flushState();
     });
 
     audio.addEventListener('timeupdate', () => {
-      this.emit('timeupdate', {
-        currentTime: audio.currentTime,
-        duration: audio.duration
-      });
-      this.saveStateThrottled();
+      const isHidden = typeof document !== 'undefined' && document.hidden;
+
+      // Skip the React fanout when the tab is hidden — PlayerBar resyncs on
+      // visibilitychange. Keep the cheap scrobble + preload checks running.
+      if (!isHidden) {
+        this.emit('timeupdate', {
+          currentTime: audio.currentTime,
+          duration: audio.duration
+        });
+      }
+
+      this.saveStateThrottled(isHidden);
 
       if (!this.hasScrobbled && this.currentTrack && audio.duration > 0) {
         const progress = audio.currentTime / audio.duration;
@@ -197,9 +213,8 @@ export class AudioPlayerService {
       this.emit('error', { error });
     });
 
-    audio.addEventListener('volumechange', () => {
-      this.emit('volumechange', { volume: this.masterVolume });
-    });
+    // Volume changes are emitted explicitly from setVolume/setMuted/applyOutputVolume.
+    // The audio element's native 'volumechange' event would double-emit here.
 
     audio.addEventListener('durationchange', () => {
       this.emit('durationchange', { duration: audio.duration });
@@ -275,6 +290,58 @@ export class AudioPlayerService {
     });
   }
 
+  private setupVisibilityHandling(): void {
+    if (typeof document === 'undefined') return;
+    if (this.visibilityListenerAttached) return;
+
+    this.onVisibilityChange = () => {
+      if (document.hidden) {
+        // Force the latest position to durable storage as the user backgrounds the app.
+        this.flushState();
+      } else {
+        // Resync any UI subscribers that suppressed updates while we were hidden.
+        this.emit('timeupdate', {
+          currentTime: this.audio.currentTime,
+          duration: this.audio.duration
+        });
+      }
+    };
+
+    this.onPageHide = () => {
+      this.flushState();
+    };
+
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('pagehide', this.onPageHide);
+    }
+    this.visibilityListenerAttached = true;
+  }
+
+  private teardownVisibilityHandling(): void {
+    if (!this.visibilityListenerAttached) return;
+    if (typeof document !== 'undefined' && this.onVisibilityChange) {
+      document.removeEventListener('visibilitychange', this.onVisibilityChange);
+    }
+    if (typeof window !== 'undefined' && this.onPageHide) {
+      window.removeEventListener('pagehide', this.onPageHide);
+    }
+    this.onVisibilityChange = null;
+    this.onPageHide = null;
+    this.visibilityListenerAttached = false;
+  }
+
+  private flushState(): void {
+    if (this.saveStateDebounced) {
+      clearTimeout(this.saveStateDebounced);
+      this.saveStateDebounced = null;
+    }
+    // Fire and forget — the IDB transaction can complete while the tab unloads.
+    this.saveState().catch(() => {
+      /* swallow: we're tearing down or backgrounded */
+    });
+  }
+
   private updateMediaSession(): void {
     if (!('mediaSession' in navigator) || !this.currentTrack) return;
 
@@ -343,14 +410,16 @@ export class AudioPlayerService {
 
     gainNode.gain.value = appliedGain;
 
-    console.log(`Playing track: ${track.title} - ${track.artists}`, {
-      replayGainMode: this.replayGainMode,
-      trackGain: track.replayGainTrackGain,
-      albumGain: track.replayGainAlbumGain,
-      usedGain: gainDb,
-      preamp: this.replayGainPreamp,
-      appliedGain: appliedGain
-    });
+    if (import.meta.env.DEV) {
+      console.log(`Playing track: ${track.title} - ${track.artists}`, {
+        replayGainMode: this.replayGainMode,
+        trackGain: track.replayGainTrackGain,
+        albumGain: track.replayGainAlbumGain,
+        usedGain: gainDb,
+        preamp: this.replayGainPreamp,
+        appliedGain: appliedGain
+      });
+    }
   }
 
   private async handleScrobble(trackId: string, submission: boolean): Promise<void> {
@@ -413,6 +482,14 @@ export class AudioPlayerService {
     this.isPreloading = false;
 
     this.isIdleReleased = true;
+
+    // Suspend the AudioContext so it doesn't keep its render thread alive
+    // through the idle period. play() already resumes a suspended context.
+    if (this.audioContext && this.audioContext.state === 'running') {
+      this.audioContext.suspend().catch(() => {
+        /* ignore — we'll try again on resume */
+      });
+    }
   }
 
   private async restoreFromIdleReleaseIfNeeded(): Promise<void> {
@@ -434,6 +511,11 @@ export class AudioPlayerService {
 
   private checkForPreload(): void {
     if (this.isPreloading || this.preloadedTrack) return;
+
+    // Don't preload while the tab is hidden — a second audio Blob in memory
+    // is wasted weight when the user isn't watching. The next track will be
+    // fetched on demand when it becomes current.
+    if (typeof document !== 'undefined' && document.hidden) return;
 
     const duration = this.audio.duration;
     const currentTime = this.audio.currentTime;
@@ -675,9 +757,12 @@ export class AudioPlayerService {
     this.saveStateDebounced = setTimeout(() => this.saveState(), 1000);
   }
 
-  private saveStateThrottled(): void {
+  private saveStateThrottled(isHidden: boolean = false): void {
+    const interval = isHidden
+      ? AudioPlayerService.SAVE_INTERVAL_HIDDEN_MS
+      : AudioPlayerService.SAVE_INTERVAL_VISIBLE_MS;
     const now = Date.now();
-    if (now - this.lastSaveTime >= 1000) {
+    if (now - this.lastSaveTime >= interval) {
       this.saveState();
     }
   }
@@ -1109,7 +1194,18 @@ export class AudioPlayerService {
     this.eventListeners.clear();
     if (this.saveStateDebounced) {
       clearTimeout(this.saveStateDebounced);
+      this.saveStateDebounced = null;
     }
+    this.cancelIdleRelease();
+    if (this.preloadAbortController) {
+      this.preloadAbortController.abort();
+      this.preloadAbortController = null;
+    }
+    if (this.preloadBlobUrl) {
+      URL.revokeObjectURL(this.preloadBlobUrl);
+      this.preloadBlobUrl = null;
+    }
+    this.teardownVisibilityHandling();
   }
 }
 

--- a/Meziantou.MusicApp.WebPlayer/src/services/play-queue-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/play-queue-service.ts
@@ -33,6 +33,19 @@ export class PlayQueueService {
   private static readonly KEEP_LOOKAHEAD_ITEMS = 30; // When trimming, keep this many items after current
   private static readonly MAX_LOOP_OFFSET = 10;
 
+  // Mutation version counter; cached getter results are valid only when their
+  // captured version matches the current `mutationVersion`.
+  private mutationVersion: number = 0;
+  private cachedQueue: { version: number; value: QueueItem[] } | null = null;
+  private cachedLookahead: { version: number; value: QueueItem[] } | null = null;
+  private cachedHistory: { version: number; value: QueueItem[] } | null = null;
+  private cachedPlaylist: { version: number; value: TrackInfo[] } | null = null;
+  private cachedShuffleOrder: { version: number; value: number[] } | null = null;
+
+  private bumpVersion(): void {
+    this.mutationVersion++;
+  }
+
   constructor(config: QueueConfig) {
     this.config = { ...config };
   }
@@ -42,6 +55,8 @@ export class PlayQueueService {
    */
   updateConfig(config: Partial<QueueConfig>): void {
     this.config = { ...this.config, ...config };
+    // updateConfig can change playlist/shuffleOrder, so invalidate caches.
+    this.bumpVersion();
   }
 
   /**
@@ -97,14 +112,24 @@ export class PlayQueueService {
    * Gets the current playlist
    */
   getPlaylist(): TrackInfo[] {
-    return [...this.config.playlist];
+    if (this.cachedPlaylist && this.cachedPlaylist.version === this.mutationVersion) {
+      return this.cachedPlaylist.value;
+    }
+    const value = [...this.config.playlist];
+    this.cachedPlaylist = { version: this.mutationVersion, value };
+    return value;
   }
 
   /**
    * Gets the shuffle order
    */
   getShuffleOrder(): number[] {
-    return [...this.config.shuffleOrder];
+    if (this.cachedShuffleOrder && this.cachedShuffleOrder.version === this.mutationVersion) {
+      return this.cachedShuffleOrder.value;
+    }
+    const value = [...this.config.shuffleOrder];
+    this.cachedShuffleOrder = { version: this.mutationVersion, value };
+    return value;
   }
 
   /**
@@ -125,23 +150,40 @@ export class PlayQueueService {
    * Gets the full queue array (history + current + lookahead)
    */
   getQueue(): QueueItem[] {
-    return [...this.queueArray];
+    if (this.cachedQueue && this.cachedQueue.version === this.mutationVersion) {
+      return this.cachedQueue.value;
+    }
+    const value = [...this.queueArray];
+    this.cachedQueue = { version: this.mutationVersion, value };
+    return value;
   }
 
   /**
    * Gets queue items after the current index (lookahead)
    */
   getLookaheadQueue(): QueueItem[] {
-    if (this.currentIndex < 0) return [...this.queueArray];
-    return this.queueArray.slice(this.currentIndex + 1);
+    if (this.cachedLookahead && this.cachedLookahead.version === this.mutationVersion) {
+      return this.cachedLookahead.value;
+    }
+    const value = this.currentIndex < 0
+      ? [...this.queueArray]
+      : this.queueArray.slice(this.currentIndex + 1);
+    this.cachedLookahead = { version: this.mutationVersion, value };
+    return value;
   }
 
   /**
    * Gets queue items before the current index (history)
    */
   getHistory(): QueueItem[] {
-    if (this.currentIndex < 0) return [];
-    return this.queueArray.slice(0, this.currentIndex);
+    if (this.cachedHistory && this.cachedHistory.version === this.mutationVersion) {
+      return this.cachedHistory.value;
+    }
+    const value = this.currentIndex < 0
+      ? []
+      : this.queueArray.slice(0, this.currentIndex);
+    this.cachedHistory = { version: this.mutationVersion, value };
+    return value;
   }
 
   /**
@@ -162,6 +204,8 @@ export class PlayQueueService {
         this.config.shuffleOrder = this.generateShuffleOrder();
       }
     }
+
+    this.bumpVersion();
   }
 
   /**
@@ -192,6 +236,7 @@ export class PlayQueueService {
     // Fill lookahead
     this.refillLookahead(playlistIndex);
 
+    this.bumpVersion();
     return true;
   }
 
@@ -220,6 +265,7 @@ export class PlayQueueService {
     }
 
     this.trimIfNeeded();
+    this.bumpVersion();
   }
 
   /**
@@ -235,6 +281,7 @@ export class PlayQueueService {
     if (index < this.currentIndex) {
       this.currentIndex--;
     }
+    this.bumpVersion();
   }
 
   /**
@@ -257,6 +304,7 @@ export class PlayQueueService {
       // Item moved from after current to at/before current
       this.currentIndex++;
     }
+    this.bumpVersion();
   }
 
   /**
@@ -279,6 +327,7 @@ export class PlayQueueService {
     this.refillLookahead();
     this.trimIfNeeded();
 
+    this.bumpVersion();
     return true;
   }
 
@@ -297,6 +346,7 @@ export class PlayQueueService {
         this.queueArray.unshift(prevItem);
         // currentIndex stays at 0 (which is now the previous track)
         this.trimIfNeeded();
+        this.bumpVersion();
         return true;
       }
       return false;
@@ -304,6 +354,7 @@ export class PlayQueueService {
 
     // Navigate backward in existing history
     this.currentIndex--;
+    this.bumpVersion();
     return true;
   }
 
@@ -351,6 +402,10 @@ export class PlayQueueService {
    * Sets shuffle enabled/disabled
    */
   setShuffle(enabled: boolean): void {
+    if (this.config.shuffleEnabled === enabled) {
+      // No actual change — don't churn cached arrays.
+      return;
+    }
     this.config.shuffleEnabled = enabled;
     if (enabled) {
       this.config.shuffleOrder = this.generateShuffleOrder();
@@ -362,13 +417,16 @@ export class PlayQueueService {
       this.queueArray = this.queueArray.slice(0, this.currentIndex + 1);
       this.refillLookahead();
     }
+    this.bumpVersion();
   }
 
   /**
    * Sets the repeat mode
    */
   setRepeatMode(mode: RepeatMode): void {
+    if (this.config.repeatMode === mode) return;
     this.config.repeatMode = mode;
+    this.bumpVersion();
   }
 
   /**
@@ -380,6 +438,7 @@ export class PlayQueueService {
 
     // Ensure we have enough lookahead
     this.refillLookahead();
+    this.bumpVersion();
   }
 
   /**

--- a/Meziantou.MusicApp.WebPlayer/src/styles/main.css
+++ b/Meziantou.MusicApp.WebPlayer/src/styles/main.css
@@ -848,6 +848,24 @@ body {
   height: 4px; /* Reset to base height when paused */
 }
 
+/* Pause infinite animations while the tab is hidden — the compositor would
+   otherwise keep ticking them in the background. */
+:root[data-hidden] .playing-animation span,
+:root[data-hidden] .download-icon.spinning {
+  animation-play-state: paused;
+}
+
+/* Honor user/OS reduced-motion preference for all infinite animations. */
+@media (prefers-reduced-motion: reduce) {
+  .playing-animation span {
+    animation: none;
+    height: 8px; /* mid-height static state */
+  }
+  .download-icon.spinning {
+    animation: none;
+  }
+}
+
 @keyframes playing-bar {
   0%, 100% { height: 4px; }
   50% { height: 16px; }

--- a/Meziantou.MusicApp.WebPlayer/src/types/app.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/types/app.ts
@@ -12,6 +12,7 @@ export interface AppSettings {
   hideTrackIndex: boolean;
   hideTrackDuration: boolean;
   hideTrackCacheStatus: boolean;
+  disablePlayingAnimation: boolean;
   replayGainMode: ReplayGainMode;
   replayGainPreamp: number; // in dB
   showReplayGainWarning: boolean;


### PR DESCRIPTION
## Motivation

When a music app tab is playing in the background, the browser still fires `timeupdate` 4x per second, triggering React re-renders for all subscribers even though no one is watching. State is also written to IndexedDB on every event, and audio preloading wastes memory the user can't see. This PR addresses all of those hot paths.

## Approach

**Background-aware rendering suppression**
- `timeupdate` no longer fans out to React subscribers while the tab is hidden. A single resync fires on `visibilitychange` when the tab comes back into focus, so the UI is always accurate when the user switches back.
- Preloading the next track is skipped while hidden -- a second audio Blob in RAM serves no one while the tab is invisible.
- The `AudioContext` is suspended during idle periods to release its render thread, and resumed automatically on `play()`.

**Smarter state persistence**
- State-save throttle extended from 1 s to 5 s (visible) / 15 s (hidden), reducing IDB write pressure significantly.
- `flushState()` is called immediately on pause and on `visibilitychange`/`pagehide`, so playback position is always durable when it matters.

**PlayQueueService result caching**
- Getters that rebuild arrays (`getQueue`, `getLookahead`, `getHistory`, `getPlaylist`, `getShuffleOrder`) now cache their results behind a mutation-version counter. Repeated reads within a single render cycle are O(1) instead of O(n).

**New `usePlayer` context**
- Introduces `PlayerProvider` / `usePlayer` so `AudioPlayerState` and `playingPlaylistId` are derived once at the tree root and consumed via context, eliminating redundant hook instantiations across sibling components.

**New "Disable Playing Track Animation" setting**
- Adds `disablePlayingAnimation` to `AppSettings`. When enabled, the animated bars that indicate the currently playing track are hidden, removing per-frame CSS animation work entirely. Described in the settings panel as "Reduces background CPU."

**Service worker update refactor**
- `useServiceWorkerUpdate` now uses a module-level registration singleton so the hourly update interval is set up exactly once per page lifetime instead of once per component mount. Also exposes a `checkForUpdate()` callback for manual checks.

**Cleanup fixes**
- `AudioPlayerService.dispose()` now cancels pending save timers, aborts preload fetches, revokes blob URLs, and removes visibility listeners.
- Duplicate `volumechange` emission from the native audio element is removed (it was double-firing alongside explicit `setVolume`/`setMuted` calls).
- ReplayGain `console.log` is gated behind `import.meta.env.DEV`.