### PR TITLE
Use scan timestamps for transcoding cache invalidation

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Unit/ImageResizingServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/ImageResizingServiceTests.cs
@@ -1,5 +1,11 @@
+using System.Reflection;
+using Meziantou.Framework;
+using Meziantou.MusicApp.Server.Models;
 using Meziantou.MusicApp.Server.Services;
 using Meziantou.MusicApp.Server.Tests.Helpers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Meziantou.MusicApp.Server.Tests.Unit;
 
@@ -44,5 +50,81 @@ public class ImageResizingServiceTests
         var result = await ResizeImage(originalImage, 100);
         Assert.NotNull(result);
         Assert.True(result.Length > 0);
+    }
+}
+
+public class TranscodingServiceTests
+{
+    [Fact]
+    public async Task TranscodeToStreamAsync_WithFreshCache_ReturnsCachedFile()
+    {
+        using var tempDir = TemporaryDirectory.Create();
+        var cachePath = tempDir / "cache";
+        var sourcePath = tempDir / "source.mp3";
+        Directory.CreateDirectory(cachePath);
+
+        using var service = CreateTranscodingService(cachePath);
+        var cacheFilePath = GetCacheFilePath(service, sourcePath, "mp3", 128);
+        var expectedContent = new byte[] { 0x11, 0x22, 0x33, 0x44 };
+        await File.WriteAllBytesAsync(cacheFilePath, expectedContent, TestContext.Current.CancellationToken);
+
+        var sourceLastWriteTimeUtc = DateTime.UtcNow.AddMinutes(-2);
+        File.SetLastWriteTimeUtc(cacheFilePath, DateTime.UtcNow.AddMinutes(-1));
+
+        await using var stream = await service.TranscodeToStreamAsync(sourcePath, "mp3", 128, sourceLastWriteTimeUtc: sourceLastWriteTimeUtc, cancellationToken: TestContext.Current.CancellationToken);
+        var fileStream = Assert.IsType<FileStream>(stream);
+
+        using var content = new MemoryStream();
+        await fileStream.CopyToAsync(content, TestContext.Current.CancellationToken);
+        Assert.Equal(expectedContent, content.ToArray());
+    }
+
+    [Fact]
+    public async Task TranscodeToStreamAsync_WithStaleCache_DoesNotServeCachedFile()
+    {
+        using var tempDir = TemporaryDirectory.Create();
+        var cachePath = tempDir / "cache";
+        var sourcePath = tempDir / "source.mp3";
+        Directory.CreateDirectory(cachePath);
+
+        using var service = CreateTranscodingService(cachePath);
+        var cacheFilePath = GetCacheFilePath(service, sourcePath, "mp3", 128);
+        await File.WriteAllBytesAsync(cacheFilePath, [0x11, 0x22, 0x33, 0x44], TestContext.Current.CancellationToken);
+
+        var sourceLastWriteTimeUtc = DateTime.UtcNow.AddMinutes(-1);
+        File.SetLastWriteTimeUtc(cacheFilePath, DateTime.UtcNow.AddMinutes(-2));
+
+        _ = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await service.TranscodeToStreamAsync(sourcePath, "mp3", 128, sourceLastWriteTimeUtc: sourceLastWriteTimeUtc, cancellationToken: TestContext.Current.CancellationToken);
+        });
+    }
+
+    private static TranscodingService CreateTranscodingService(string cachePath)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["FFmpeg:Path"] = "ffmpeg-does-not-exist",
+                ["FFmpeg:MaxConcurrentTranscodes"] = "1",
+            })
+            .Build();
+
+        var settings = Options.Create(new MusicServerSettings
+        {
+            CachePath = cachePath,
+            EnableTranscodingCache = true,
+        });
+
+        return new TranscodingService(NullLogger<TranscodingService>.Instance, configuration, settings);
+    }
+
+    private static string GetCacheFilePath(TranscodingService service, string inputPath, string? outputFormat, int? maxBitRate)
+    {
+        var method = typeof(TranscodingService).GetMethod("GetCacheFilePath", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var value = method.Invoke(service, [inputPath, outputFormat, maxBitRate]);
+        return Assert.IsType<string>(value);
     }
 }

--- a/Meziantou.MusicApp.Server/Controllers/JellyfinController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/JellyfinController.cs
@@ -285,6 +285,7 @@ public class JellyfinController : ControllerBase
                 targetFormat,
                 targetBitRate,
                 null,
+                song.FileLastWriteTimeUtc,
                 HttpContext.RequestAborted);
 #pragma warning restore CA2000
 

--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -160,6 +160,7 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
                 format,
                 maxBitRate,
                 timeOffset,
+                song.FileLastWriteTimeUtc,
                 cancellationToken);
 
             var contentType = format switch

--- a/Meziantou.MusicApp.Server/Controllers/SubsonicController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/SubsonicController.cs
@@ -383,6 +383,7 @@ public class SubsonicController : ControllerBase
                 format,
                 maxBitRate,
                 timeOffset,
+                song.FileLastWriteTimeUtc,
                 HttpContext.RequestAborted);
 
             var contentType = TranscodingService.GetContentType(format);

--- a/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
+++ b/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
@@ -128,6 +128,7 @@ public sealed class MusicCatalog
                     BitRate = serializableSong.BitRate == 0 ? null : serializableSong.BitRate,
                     Size = serializableSong.FileSize,
                     Created = serializableSong.FileCreatedAt,
+                    FileLastWriteTimeUtc = serializableSong.FileLastWriteTime,
                     Suffix = Path.GetExtension(serializableSong.RelativePath).TrimStart('.').ToLowerInvariant(),
                     ContentType = GetContentType(Path.GetExtension(serializableSong.RelativePath)),
                     Lyrics = lyrics,

--- a/Meziantou.MusicApp.Server/Models/Song.cs
+++ b/Meziantou.MusicApp.Server/Models/Song.cs
@@ -19,6 +19,7 @@ public sealed class Song
     public int Duration { get; init; }
     public int? BitRate { get; init; }
     public DateTime Created { get; init; }
+    public DateTime FileLastWriteTimeUtc { get; init; }
     public string? ParentId { get; set; }
     public CoverArt? CoverArt { get; set; }
     public Lyrics? Lyrics { get; init; }

--- a/Meziantou.MusicApp.Server/Services/TranscodingService.cs
+++ b/Meziantou.MusicApp.Server/Services/TranscodingService.cs
@@ -28,6 +28,7 @@ public sealed class TranscodingService : IDisposable
         string? outputFormat = null,
         int? maxBitRate = null,
         int? timeOffset = null,
+        DateTime? sourceLastWriteTimeUtc = null,
         CancellationToken cancellationToken = default)
     {
         string? cacheFilePath = null;
@@ -36,11 +37,23 @@ public sealed class TranscodingService : IDisposable
             cacheFilePath = GetCacheFilePath(inputPath, outputFormat, maxBitRate);
             if (File.Exists(cacheFilePath))
             {
-                _logger.LogInformation("Serving from cache: {CachePath}", cacheFilePath);
                 try
                 {
-                    // File.SetLastAccessTimeUtc(cacheFilePath, DateTime.UtcNow);
-                    return new FileStream(cacheFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
+                    if (!sourceLastWriteTimeUtc.HasValue)
+                    {
+                        _logger.LogInformation("Ignoring cache because source timestamp is missing: {CachePath}", cacheFilePath);
+                    }
+                    else if (!IsCacheFileFresh(sourceLastWriteTimeUtc.Value, cacheFilePath))
+                    {
+                        _logger.LogInformation("Ignoring stale cache: {CachePath}", cacheFilePath);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Serving from cache: {CachePath}", cacheFilePath);
+
+                        // File.SetLastAccessTimeUtc(cacheFilePath, DateTime.UtcNow);
+                        return new FileStream(cacheFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -109,6 +122,24 @@ public sealed class TranscodingService : IDisposable
             _transcodingSemaphore.Release();
             throw;
         }
+    }
+
+    private bool IsCacheFileFresh(DateTime sourceLastWriteTimeUtc, string cacheFilePath)
+    {
+        var cacheLastWriteTimeUtc = File.GetLastWriteTimeUtc(cacheFilePath);
+
+        if (cacheLastWriteTimeUtc < sourceLastWriteTimeUtc)
+        {
+            _logger.LogInformation(
+                "Cached transcoded file is stale. Cache: {CachePath}, CacheLastWriteTimeUtc: {CacheLastWriteTimeUtc}, SourceLastWriteTimeUtc: {SourceLastWriteTimeUtc}",
+                cacheFilePath,
+                cacheLastWriteTimeUtc,
+                sourceLastWriteTimeUtc);
+
+            return false;
+        }
+
+        return true;
     }
 
     private string GetCacheFilePath(string inputPath, string? outputFormat, int? maxBitRate)


### PR DESCRIPTION
## Why

Transcoding cache freshness was checked using disk reads in request-time code. That can drift from the library scan state and adds extra file metadata I/O on each cached request.

## What changed

- `TranscodingService.TranscodeToStreamAsync` now accepts `sourceLastWriteTimeUtc` and uses that value to validate cache freshness.
- Cache freshness no longer reads the source file last-write time from disk.
- Transcoding call sites now pass scan-derived timestamps from `Song.FileLastWriteTimeUtc`:
  - `SubsonicController`
  - `RestApiController`
  - `JellyfinController`
- `Song` now carries `FileLastWriteTimeUtc`, populated from `SerializableSong.FileLastWriteTime` in `MusicCatalog`.
- Regression tests were updated/added to cover:
  - cache hit with a fresh cache using caller-provided source timestamp
  - stale cache bypass when source timestamp is newer

## Notes

- If a source timestamp is not provided, the cache is intentionally skipped.

## Validation

- `dotnet test --nologo`