### PR TITLE
Add transcoding cache cleanup endpoint and settings action

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
@@ -66,6 +66,44 @@ public class RestApiIntegrationTests
     }
 
     [Fact]
+    public async Task CleanupTranscodingCache_DeletesOnlyTranscodingFiles()
+    {
+        await using var app = AppTestContext.Create();
+
+        app.MusicCachePath.CreateParentDirectory();
+        await File.WriteAllTextAsync(app.MusicCachePath, "{}", app.CancellationToken);
+
+        var coverFilePath = app.CachePath / "cover" / "cover.jpg";
+        coverFilePath.CreateParentDirectory();
+        await File.WriteAllBytesAsync(coverFilePath, [0x01, 0x02], app.CancellationToken);
+
+        var transcodingCacheFile = app.CachePath / $"{new string('a', 64)}.mp3";
+        var transcodingCacheTempFile = app.CachePath / $"{new string('b', 64)}.opus.tmp";
+        await File.WriteAllBytesAsync(transcodingCacheFile, [0x03], app.CancellationToken);
+        await File.WriteAllBytesAsync(transcodingCacheTempFile, [0x04], app.CancellationToken);
+
+        using var response = await app.Client.PostAsync("/api/cache/transcoding/cleanup.json", content: null, app.CancellationToken);
+        InlineSnapshot.Validate(response, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: no-store, must-revalidate, no-cache
+            Content:
+              Headers:
+                Content-Type: application/json; charset=utf-8
+              Value:
+                {
+                  "deletedFileCount": 2,
+                  "failedFileCount": 0
+                }
+            """);
+
+        Assert.False(File.Exists(transcodingCacheFile));
+        Assert.False(File.Exists(transcodingCacheTempFile));
+        Assert.True(File.Exists(app.MusicCachePath));
+        Assert.True(File.Exists(coverFilePath));
+    }
+
+    [Fact]
     public async Task GetScanStatus_WithValidAuth_ReturnsStatus()
     {
         // Act

--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -390,6 +390,19 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
         });
     }
 
+    /// <summary>Delete cached transcoded files</summary>
+    [HttpPost("cache/transcoding/cleanup.json")]
+    [ProducesResponseType<CacheCleanupResponse>(StatusCodes.Status200OK)]
+    public ActionResult<CacheCleanupResponse> CleanupTranscodingCache()
+    {
+        var result = transcoding.CleanupTranscodingCache();
+        return Ok(new CacheCleanupResponse
+        {
+            DeletedFileCount = result.DeletedFileCount,
+            FailedFileCount = result.FailedFileCount,
+        });
+    }
+
     /// <summary>Get lyrics for a song</summary>
     [HttpGet("songs/{id}/lyrics.json")]
     [ProducesResponseType<LyricsResponse>(StatusCodes.Status200OK)]

--- a/Meziantou.MusicApp.Server/Models/RestApi/CacheCleanupResponse.cs
+++ b/Meziantou.MusicApp.Server/Models/RestApi/CacheCleanupResponse.cs
@@ -1,0 +1,7 @@
+namespace Meziantou.MusicApp.Server.Models.RestApi;
+
+public sealed class CacheCleanupResponse
+{
+    public int DeletedFileCount { get; set; }
+    public int FailedFileCount { get; set; }
+}

--- a/Meziantou.MusicApp.Server/README.md
+++ b/Meziantou.MusicApp.Server/README.md
@@ -9,7 +9,7 @@ This project is a music streaming server that supports both Subsonic and Jellyfi
 - ID3 tag reading using Meziantou.Framework.MediaTags
 - Lyrics support from file metadata
 - Cover art extraction from files or folders
-- Read-only API surface (except manual library rescan endpoint)
+- Read-only API surface (except manual library rescan and transcoding cache cleanup endpoints)
 - Token values are accepted without validation
 - Audio transcoding with FFmpeg support
 - ReplayGain Support: Read and compute ReplayGain for volume normalization

--- a/Meziantou.MusicApp.Server/Services/TranscodingService.cs
+++ b/Meziantou.MusicApp.Server/Services/TranscodingService.cs
@@ -7,6 +7,8 @@ namespace Meziantou.MusicApp.Server.Services;
 
 public sealed class TranscodingService : IDisposable
 {
+    public readonly record struct CacheCleanupResult(int DeletedFileCount, int FailedFileCount);
+
     private readonly ILogger<TranscodingService> _logger;
     private readonly string _ffmpegPath;
     private readonly SemaphoreSlim _transcodingSemaphore;
@@ -148,6 +150,74 @@ public sealed class TranscodingService : IDisposable
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key)));
         var fileName = $"{hash}.{outputFormat ?? "mp3"}";
         return Path.Combine(_settings.CachePath, fileName);
+    }
+
+    public CacheCleanupResult CleanupTranscodingCache()
+    {
+        if (string.IsNullOrWhiteSpace(_settings.CachePath))
+        {
+            return new CacheCleanupResult(DeletedFileCount: 0, FailedFileCount: 0);
+        }
+
+        if (!Directory.Exists(_settings.CachePath))
+        {
+            return new CacheCleanupResult(DeletedFileCount: 0, FailedFileCount: 0);
+        }
+
+        var deletedFileCount = 0;
+        var failedFileCount = 0;
+
+        foreach (var filePath in Directory.EnumerateFiles(_settings.CachePath, "*", SearchOption.TopDirectoryOnly))
+        {
+            var fileName = Path.GetFileName(filePath);
+            if (!IsTranscodingCacheFileName(fileName))
+            {
+                continue;
+            }
+
+            try
+            {
+                File.Delete(filePath);
+                deletedFileCount++;
+            }
+            catch (Exception ex)
+            {
+                failedFileCount++;
+                _logger.LogWarning(ex, "Failed to delete transcoding cache file: {Path}", filePath);
+            }
+        }
+
+        return new CacheCleanupResult(DeletedFileCount: deletedFileCount, FailedFileCount: failedFileCount);
+    }
+
+    private static bool IsTranscodingCacheFileName(string fileName)
+    {
+        if (fileName.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase))
+        {
+            fileName = fileName[..^4];
+        }
+
+        var extension = Path.GetExtension(fileName);
+        if (string.IsNullOrEmpty(extension))
+        {
+            return false;
+        }
+
+        var hash = Path.GetFileNameWithoutExtension(fileName);
+        if (hash.Length != 64)
+        {
+            return false;
+        }
+
+        foreach (var character in hash)
+        {
+            if (!char.IsAsciiHexDigit(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static string BuildFFmpegArguments(

--- a/Meziantou.MusicApp.Server/Services/TranscodingService.cs
+++ b/Meziantou.MusicApp.Server/Services/TranscodingService.cs
@@ -7,8 +7,6 @@ namespace Meziantou.MusicApp.Server.Services;
 
 public sealed class TranscodingService : IDisposable
 {
-    public readonly record struct CacheCleanupResult(int DeletedFileCount, int FailedFileCount);
-
     private readonly ILogger<TranscodingService> _logger;
     private readonly string _ffmpegPath;
     private readonly SemaphoreSlim _transcodingSemaphore;
@@ -152,16 +150,16 @@ public sealed class TranscodingService : IDisposable
         return Path.Combine(_settings.CachePath, fileName);
     }
 
-    public CacheCleanupResult CleanupTranscodingCache()
+    public (int DeletedFileCount, int FailedFileCount) CleanupTranscodingCache()
     {
         if (string.IsNullOrWhiteSpace(_settings.CachePath))
         {
-            return new CacheCleanupResult(DeletedFileCount: 0, FailedFileCount: 0);
+            return (DeletedFileCount: 0, FailedFileCount: 0);
         }
 
         if (!Directory.Exists(_settings.CachePath))
         {
-            return new CacheCleanupResult(DeletedFileCount: 0, FailedFileCount: 0);
+            return (DeletedFileCount: 0, FailedFileCount: 0);
         }
 
         var deletedFileCount = 0;
@@ -187,7 +185,7 @@ public sealed class TranscodingService : IDisposable
             }
         }
 
-        return new CacheCleanupResult(DeletedFileCount: deletedFileCount, FailedFileCount: failedFileCount);
+        return (DeletedFileCount: deletedFileCount, FailedFileCount: failedFileCount);
     }
 
     private static bool IsTranscodingCacheFileName(string fileName)

--- a/Meziantou.MusicApp.WebPlayer/README.md
+++ b/Meziantou.MusicApp.WebPlayer/README.md
@@ -14,7 +14,7 @@ The features
 - AirPlay: Stream audio to AirPlay devices on Safari/macOS
 - Media Session API: System-level media controls and notifications
 - Dark Theme: Easy on the eyes
-- Read-only server interaction (except manual and force library rescans)
+- Read-only server interaction (except manual/force library rescans and transcoding cache cleanup)
 - State persistence: Playback state saved in IndexedDB
 - Auto-resume: Continues playback on app reopen
 - Background sync: Periodic playlist refresh (5 min intervals)

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -28,12 +28,13 @@ interface SettingsDialogProps {
 }
 
 export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsDialogProps) {
-  const { settings, updateSettings, testConnection, triggerLibraryScan, isOnline } = useApp();
+  const { settings, updateSettings, testConnection, triggerLibraryScan, cleanupTranscodingCache, isOnline } = useApp();
   const { checkForUpdate, needRefresh, updateServiceWorker } = useServiceWorkerUpdate();
 
   const [formData, setFormData] = useState<AppSettings>(settings);
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [scanStatus, setScanStatus] = useState<'idle' | 'scanning' | 'force-scanning'>('idle');
+  const [cacheCleanupStatus, setCacheCleanupStatus] = useState<'idle' | 'cleaning'>('idle');
   const [updateStatus, setUpdateStatus] = useState<'idle' | 'checking' | 'up-to-date' | 'error'>('idle');
   const settingsRef = useRef(settings);
   const prevIsOpenRef = useRef(isOpen);
@@ -84,6 +85,15 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
       await triggerLibraryScan(true);
     } finally {
       setScanStatus('idle');
+    }
+  };
+
+  const handleCleanupTranscodingCache = async () => {
+    setCacheCleanupStatus('cleaning');
+    try {
+      await cleanupTranscodingCache();
+    } finally {
+      setCacheCleanupStatus('idle');
     }
   };
 
@@ -387,6 +397,16 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
                   style={{ width: '100%' }}
                 >
                   Cache Diagnostics
+                </button>
+              </div>
+              <div className="form-group">
+                <button
+                  className="secondary-button"
+                  onClick={handleCleanupTranscodingCache}
+                  disabled={cacheCleanupStatus !== 'idle'}
+                  style={{ width: '100%', marginBottom: '8px' }}
+                >
+                  {cacheCleanupStatus === 'cleaning' ? 'Cleaning...' : 'Clean Transcoding Cache'}
                 </button>
               </div>
             </section>

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -61,6 +61,7 @@ interface AppContextValue {
 
   // Library scan
   triggerLibraryScan: (force?: boolean) => Promise<void>;
+  cleanupTranscodingCache: () => Promise<void>;
 }
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -844,6 +845,40 @@ function AppDataProvider({ children }: AppProviderProps) {
     }
   }, [isOnline, settings.serverUrl, showToast]);
 
+  const cleanupTranscodingCache = useCallback(async () => {
+    if (!isOnline) {
+      showToast('Cannot clean transcoding cache while offline', 'error');
+      return;
+    }
+
+    if (!settings.serverUrl) {
+      showToast('Server is not configured', 'error');
+      return;
+    }
+
+    try {
+      const api = getApiService();
+      const response = await api.cleanupTranscodingCache();
+
+      if (response.failedFileCount > 0) {
+        showToast(
+          `Transcoding cache cleanup completed (${response.deletedFileCount} deleted, ${response.failedFileCount} failed)`,
+          'error',
+        );
+        return;
+      }
+
+      if (response.deletedFileCount > 0) {
+        showToast(`Transcoding cache cleaned (${response.deletedFileCount} files removed)`, 'success');
+      } else {
+        showToast('Transcoding cache is already clean', 'info');
+      }
+    } catch (error) {
+      console.error('Failed to clean transcoding cache:', error);
+      showToast('Failed to clean transcoding cache', 'error');
+    }
+  }, [isOnline, settings.serverUrl, showToast]);
+
   const syncPlaylists = useCallback(async () => {
     await syncPlaylistsInternal();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -980,6 +1015,7 @@ function AppDataProvider({ children }: AppProviderProps) {
     removeTrackFromPlaylist,
     testConnection,
     triggerLibraryScan,
+    cleanupTranscodingCache,
   }), [
     settings,
     updateSettings,
@@ -1009,6 +1045,7 @@ function AppDataProvider({ children }: AppProviderProps) {
     removeTrackFromPlaylist,
     testConnection,
     triggerLibraryScan,
+    cleanupTranscodingCache,
   ]);
 
   return (

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.test.ts
@@ -38,4 +38,24 @@ describe('ApiService', () => {
       expect.objectContaining({ method: 'POST' }),
     );
   });
+
+  it('cleanupTranscodingCache calls cleanup endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        deletedFileCount: 3,
+        failedFileCount: 0,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new ApiService('https://example.com');
+    await service.cleanupTranscodingCache();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/api/cache/transcoding/cleanup.json',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
 });

--- a/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/api-service.ts
@@ -2,6 +2,7 @@ import type {
   PlaylistsResponse,
   PlaylistTracksResponse,
   ScanStatusResponse,
+  CacheCleanupResponse,
   StreamingQuality,
   LyricsResponse
 } from '../types';
@@ -57,6 +58,10 @@ export class ApiService {
   async triggerScan(force = false): Promise<ScanStatusResponse> {
     const query = force ? '?force=true' : '';
     return this.fetch<ScanStatusResponse>(`/api/scan.json${query}`, { method: 'POST' });
+  }
+
+  async cleanupTranscodingCache(): Promise<CacheCleanupResponse> {
+    return this.fetch<CacheCleanupResponse>('/api/cache/transcoding/cleanup.json', { method: 'POST' });
   }
 
   getSongStreamUrl(songId: string, quality: StreamingQuality): string {

--- a/Meziantou.MusicApp.WebPlayer/src/types/api.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/types/api.ts
@@ -100,6 +100,11 @@ export interface ScanStatusResponse {
   invalidPlaylists: InvalidPlaylistInfo[];
 }
 
+export interface CacheCleanupResponse {
+  deletedFileCount: number;
+  failedFileCount: number;
+}
+
 export interface ErrorResponse {
   error: string;
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A dual-API music server supporting both **Subsonic** and **Jellyfin** protocols.
 - Dual API support (Subsonic & Jellyfin)
 - On-the-fly transcoding with FFmpeg
 - ReplayGain support
-- Read-only API surface with manual library rescan support
+- Read-only API surface with manual library rescan and transcoding cache cleanup support
 
 ### [Meziantou.MusicApp.WebPlayer](Meziantou.MusicApp.WebPlayer/README.md)
 


### PR DESCRIPTION
## Why
Managing transcoding cache currently requires manual file cleanup on the server. This change adds a safe maintenance path so users can clear only transcoding artifacts from the API and trigger it from the web player settings UI.

## What changed
- Added `POST /api/cache/transcoding/cleanup.json` to the REST API.
- Added `CacheCleanupResponse` with `deletedFileCount` and `failedFileCount`.
- Implemented `TranscodingService.CleanupTranscodingCache()` with strict targeting of transcoding cache files only:
  - top-level files in `MusicServer.CachePath`
  - names matching the transcoding hash format (including `.tmp` variants)
  - preserves `cache.json` and `cover/` cached assets
- Added integration coverage in `RestApiIntegrationTests` to verify only transcoding files are deleted.
- Added web player support:
  - API client method `cleanupTranscodingCache()`
  - app hook action in `useApp` with success/error toast messaging
  - new **Clean Transcoding Cache** button in **Settings -> Advanced** with loading/disabled state
- Updated README docs to include this maintenance endpoint as an explicit read-only exception.

## Notes for reviewers
The cleanup intentionally avoids recursive deletion and only removes files that match the server's transcoding cache naming scheme, to prevent accidental removal of unrelated cache content.

## Validation
- `dotnet test --nologo`
- `cd Meziantou.MusicApp.WebPlayer && npm test`
- `cd Meziantou.MusicApp.WebPlayer && npm run build`