### PR TITLE
Keep player bar cover click target when cover art is hidden

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.test.tsx
@@ -1,0 +1,67 @@
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CoverImage } from './CoverImage';
+
+const useAppMock = vi.fn();
+
+vi.mock('../hooks', () => ({
+  useApp: () => useAppMock(),
+}));
+
+vi.mock('../services', () => ({
+  getApiService: vi.fn(() => ({
+    getSongCoverUrl: vi.fn(),
+    getCoverHeaders: vi.fn(() => ({})),
+  })),
+  storageService: {
+    getCachedCover: vi.fn(),
+    isCoverMissing: vi.fn(),
+    saveCachedCover: vi.fn(),
+    addMissingCover: vi.fn(),
+  },
+}));
+
+vi.mock('../utils', () => ({
+  getNetworkType: vi.fn(() => 'wifi'),
+}));
+
+describe('CoverImage', () => {
+  beforeEach(() => {
+    useAppMock.mockReturnValue({
+      cachedTrackIds: new Set<string>(),
+      settings: { hideCoverArt: true },
+    });
+  });
+
+  it('hides image when cover art is disabled and no opt-in is provided', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<CoverImage trackId="track-1" size={64} alt="cover" />);
+    });
+    expect(container.querySelector('img')).toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('shows placeholder when cover art is disabled and opt-in is enabled', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<CoverImage trackId="track-1" size={64} alt="cover" showPlaceholderWhenHidden />);
+    });
+
+    const image = container.querySelector('img');
+    expect(image).not.toBeNull();
+    expect(image).toHaveAttribute('src', expect.stringContaining('data:image/svg+xml'));
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.tsx
@@ -40,6 +40,7 @@ interface CoverImageProps {
   className?: string;
   alt?: string;
   onClick?: () => void;
+  showPlaceholderWhenHidden?: boolean;
 }
 
 export function CoverImage({
@@ -48,6 +49,7 @@ export function CoverImage({
   className = '',
   alt = '',
   onClick,
+  showPlaceholderWhenHidden = false,
 }: CoverImageProps) {
   const { cachedTrackIds, settings } = useApp();
   const [coverSrc, setCoverSrc] = useState(COVER_PLACEHOLDER_DATA_URI);
@@ -148,7 +150,7 @@ export function CoverImage({
     };
   }, [trackId, size, isTrackCached, settings.hideCoverArt]);
 
-  if (settings.hideCoverArt) {
+  if (settings.hideCoverArt && !showPlaceholderWhenHidden) {
     return null;
   }
 

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.test.tsx
@@ -1,0 +1,81 @@
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlayerBar } from './PlayerBar';
+
+const useAppMock = vi.fn();
+const usePlayerMock = vi.fn();
+
+vi.mock('../hooks', () => ({
+  useApp: () => useAppMock(),
+  usePlayer: () => usePlayerMock(),
+}));
+
+vi.mock('../services', () => ({
+  audioPlayer: {
+    getCurrentTime: vi.fn(() => 0),
+    getDuration: vi.fn(() => 0),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+vi.mock('./CoverImage', () => ({
+  CoverImage: ({ showPlaceholderWhenHidden }: { showPlaceholderWhenHidden?: boolean }) => (
+    <div data-testid="player-cover-placeholder-optin">{String(showPlaceholderWhenHidden)}</div>
+  ),
+}));
+
+describe('PlayerBar', () => {
+  beforeEach(() => {
+    useAppMock.mockReturnValue({
+      currentPlaylistId: null,
+      selectPlaylist: vi.fn().mockResolvedValue(undefined),
+      playlists: [],
+    });
+
+    usePlayerMock.mockReturnValue({
+      playerState: {
+        currentTrack: null,
+        currentQuality: null,
+        isPlaying: false,
+        shuffleEnabled: false,
+        repeatMode: 'off',
+        queue: [],
+        isAirPlayAvailable: false,
+        isAirPlayActive: false,
+        volume: 1,
+        isMuted: false,
+      },
+      playerActions: {
+        seek: vi.fn(),
+        previous: vi.fn(),
+        next: vi.fn(),
+        setShuffle: vi.fn(),
+        togglePlayPause: vi.fn(),
+        cycleRepeatMode: vi.fn(),
+        toggleMute: vi.fn(),
+        setVolume: vi.fn(),
+        getCurrentPlaylistId: vi.fn(() => null),
+        showAirPlayPicker: vi.fn(),
+      },
+    });
+  });
+
+  it('enables placeholder opt-in for the cover image', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<PlayerBar onQueueClick={() => undefined} />);
+    });
+
+    const element = container.querySelector('[data-testid="player-cover-placeholder-optin"]');
+    expect(element).not.toBeNull();
+    expect(element).toHaveTextContent('true');
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
@@ -199,6 +199,7 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
           className="player-cover"
           alt=""
           onClick={handleCoverClick}
+          showPlaceholderWhenHidden
         />
         <div className="player-track-details">
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', minWidth: 0 }}>

--- a/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+// Enable React act() support for createRoot-based tests.
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
 // Mock HTMLMediaElement
 Object.defineProperty(window.HTMLMediaElement.prototype, 'play', {
   configurable: true,


### PR DESCRIPTION
When cover art is hidden in settings, the bottom player bar lost its cover element, so the click shortcut to focus the currently playing track in the playlist was no longer available.

This change keeps that shortcut available without re-enabling real cover loading.

## What changed
- Added a `showPlaceholderWhenHidden` opt-in prop to `CoverImage`.
- Preserved default behavior for hidden cover art: `CoverImage` still renders nothing unless explicitly opted in.
- Updated `PlayerBar` to opt in, so it still renders a placeholder cover image and keeps the existing click behavior.
- Added component tests for both behaviors:
  - `CoverImage` stays hidden by default when cover art is disabled.
  - `PlayerBar` enables the opt-in placeholder path.
- Enabled React act environment support in test setup for stable createRoot component tests.

## Notes for reviewers
- This is intentionally scoped to the bottom player bar interaction.
- Hidden cover art still does not load actual cover images.