### PR TITLE
Add 10-band equalizer with persistent WebPlayer settings

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/README.md
+++ b/Meziantou.MusicApp.WebPlayer/README.md
@@ -11,6 +11,7 @@ The features
 - Auto-sync: Background playlist refresh and automatic track downloading
 - Search: Quick search across tracks, artists, and albums
 - Playback Controls: Play, pause, seek, shuffle, repeat modes
+- 10-band Equalizer: Real-time EQ controls (31Hz to 16kHz) in the player bar
 - AirPlay: Stream audio to AirPlay devices on Safari/macOS
 - Media Session API: System-level media controls and notifications
 - Dark Theme: Easy on the eyes
@@ -70,6 +71,7 @@ In the future, I want to support more backend servers like Subsonic, Airsonic, s
 - Play/pause button
 - Seek slider with current time and total duration
 - Volume control slider
+- 10-band equalizer popover with per-band sliders and reset
 - Shuffle and repeat buttons
 - Clicking on the cover shows the current playlist and scrolls to the current track
 

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.test.tsx
@@ -2,6 +2,7 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PlayerBar } from './PlayerBar';
+import { DEFAULT_EQUALIZER_GAINS } from '../constants';
 
 const useAppMock = vi.fn();
 const usePlayerMock = vi.fn();
@@ -32,6 +33,10 @@ describe('PlayerBar', () => {
       currentPlaylistId: null,
       selectPlaylist: vi.fn().mockResolvedValue(undefined),
       playlists: [],
+      settings: {
+        equalizerGains: [...DEFAULT_EQUALIZER_GAINS],
+      },
+      setEqualizerGains: vi.fn(),
     });
 
     usePlayerMock.mockReturnValue({
@@ -73,6 +78,28 @@ describe('PlayerBar', () => {
     const element = container.querySelector('[data-testid="player-cover-placeholder-optin"]');
     expect(element).not.toBeNull();
     expect(element).toHaveTextContent('true');
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('shows 10 equalizer sliders when toggled open', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<PlayerBar onQueueClick={() => undefined} />);
+    });
+
+    const toggleButton = container.querySelector('button[aria-label="Toggle equalizer"]') as HTMLButtonElement;
+    expect(toggleButton).not.toBeNull();
+
+    act(() => {
+      toggleButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelectorAll('.equalizer-slider')).toHaveLength(10);
 
     act(() => {
       root.unmount();

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.tsx
@@ -1,5 +1,11 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { RepeatMode } from '../types';
+import {
+  EQUALIZER_FREQUENCIES,
+  EQUALIZER_MAX_GAIN_DB,
+  EQUALIZER_MIN_GAIN_DB,
+  DEFAULT_EQUALIZER_GAINS,
+} from '../constants';
 import { formatDuration } from '../utils';
 import { useApp, usePlayer } from '../hooks';
 import { audioPlayer, type PlayerEventDetail } from '../services';
@@ -22,8 +28,30 @@ const getFormatColor = (format: string) => {
   }
 };
 
+const formatEqualizerFrequency = (frequency: number): string => {
+  if (frequency >= 1000) {
+    return `${frequency / 1000}k`;
+  }
+
+  return `${frequency}`;
+};
+
+const formatEqualizerGain = (gain: number): string => {
+  if (gain > 0) {
+    return `+${gain} dB`;
+  }
+
+  return `${gain} dB`;
+};
+
 export function PlayerBar({ onQueueClick }: PlayerBarProps) {
-  const { currentPlaylistId, selectPlaylist, playlists } = useApp();
+  const {
+    currentPlaylistId,
+    selectPlaylist,
+    playlists,
+    settings,
+    setEqualizerGains,
+  } = useApp();
   const { playerState, playerActions } = usePlayer();
   const [currentTime, setCurrentTime] = useState(() => audioPlayer.getCurrentTime());
   const [duration, setDuration] = useState(() => audioPlayer.getDuration());
@@ -72,6 +100,8 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
   }, [isDragging, handleSeek]);
 
   const [isVolumePopoverVisible, setIsVolumePopoverVisible] = useState(false);
+  const [isEqualizerOpen, setIsEqualizerOpen] = useState(false);
+  const [equalizerGains, setEqualizerGainsState] = useState<number[]>(() => settings.equalizerGains);
   const volumePopoverTimeoutRef = useRef<number | undefined>(undefined);
   const volumeRafRef = useRef<number | null>(null);
   const pendingVolumeRef = useRef<number | null>(null);
@@ -186,9 +216,28 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
     }
   }, [playerState.currentTrack]);
 
+  useEffect(() => {
+    setEqualizerGainsState(settings.equalizerGains);
+  }, [settings.equalizerGains]);
+
   const progressPercent = duration > 0
     ? (currentTime / duration) * 100
     : 0;
+
+  const handleEqualizerChange = (bandIndex: number, gainValue: number) => {
+    setEqualizerGainsState(prev => {
+      const next = [...prev];
+      next[bandIndex] = gainValue;
+      setEqualizerGains(next);
+      return next;
+    });
+  };
+
+  const handleResetEqualizer = () => {
+    const resetGains = [...DEFAULT_EQUALIZER_GAINS];
+    setEqualizerGainsState(resetGains);
+    setEqualizerGains(resetGains);
+  };
 
   return (
     <div className="player-bar">
@@ -308,6 +357,40 @@ export function PlayerBar({ onQueueClick }: PlayerBarProps) {
               onClick={() => playerActions.showAirPlayPicker()}
             />
           )}
+          <div className="player-equalizer">
+            <EqualizerButton
+              active={isEqualizerOpen}
+              onClick={() => setIsEqualizerOpen(prev => !prev)}
+            />
+            {isEqualizerOpen && (
+              <div className="equalizer-popover" role="dialog" aria-label="Equalizer settings">
+                <div className="equalizer-header">
+                  <strong>Equalizer</strong>
+                  <button className="equalizer-reset-button" onClick={handleResetEqualizer}>
+                    Reset
+                  </button>
+                </div>
+                <div className="equalizer-bands">
+                  {EQUALIZER_FREQUENCIES.map((frequency, index) => (
+                    <label className="equalizer-band" key={frequency}>
+                      <span className="equalizer-frequency">{formatEqualizerFrequency(frequency)}</span>
+                      <input
+                        type="range"
+                        min={EQUALIZER_MIN_GAIN_DB}
+                        max={EQUALIZER_MAX_GAIN_DB}
+                        step="1"
+                        value={equalizerGains[index] ?? 0}
+                        aria-label={`${frequency} Hz`}
+                        className="equalizer-slider"
+                        onChange={(e) => handleEqualizerChange(index, parseInt(e.target.value, 10))}
+                      />
+                      <span className="equalizer-gain">{formatEqualizerGain(equalizerGains[index] ?? 0)}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
           <QueueButton
             queueLength={playerState.queue.length}
             onClick={onQueueClick}
@@ -469,6 +552,21 @@ function QueueButton({ queueLength, onClick }: { queueLength: number; onClick: (
           {queueLength > 99 ? '99+' : queueLength}
         </span>
       )}
+    </button>
+  );
+}
+
+function EqualizerButton({ active, onClick }: { active: boolean; onClick: () => void }) {
+  return (
+    <button
+      className={`icon-button equalizer-btn ${active ? 'active' : ''}`}
+      title="Equalizer"
+      aria-label="Toggle equalizer"
+      onClick={onClick}
+    >
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M4 21h2v-7H4v7zm7 0h2V3h-2v18zm7 0h2v-11h-2v11zM4 10h2V3H4v7zm14-3h2V3h-2v4zm0 14h2v-10h-2v10zM11 9h2V7h-2v2z" />
+      </svg>
     </button>
   );
 }

--- a/Meziantou.MusicApp.WebPlayer/src/constants.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/constants.ts
@@ -1,5 +1,25 @@
 import type { AppSettings, PlaybackState } from './types';
 
+export const EQUALIZER_FREQUENCIES = [31, 62, 125, 250, 500, 1000, 2000, 4000, 8000, 16000] as const;
+export const EQUALIZER_MIN_GAIN_DB = -12;
+export const EQUALIZER_MAX_GAIN_DB = 12;
+export const DEFAULT_EQUALIZER_GAINS = EQUALIZER_FREQUENCIES.map(() => 0);
+
+function clampEqualizerGain(gain: number): number {
+  return Math.min(EQUALIZER_MAX_GAIN_DB, Math.max(EQUALIZER_MIN_GAIN_DB, gain));
+}
+
+export function normalizeEqualizerGains(gains: readonly number[] | null | undefined): number[] {
+  return EQUALIZER_FREQUENCIES.map((_, index) => {
+    const value = gains?.[index];
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return 0;
+    }
+
+    return clampEqualizerGain(value);
+  });
+}
+
 export const DEFAULT_SETTINGS: AppSettings = {
   serverUrl: '',
   normalQuality: { format: 'opus', maxBitRate: 160 },
@@ -13,7 +33,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   disablePlayingAnimation: false,
   replayGainMode: 'off',
   replayGainPreamp: 0,
-  showReplayGainWarning: true
+  showReplayGainWarning: true,
+  equalizerGains: [...DEFAULT_EQUALIZER_GAINS],
 };
 
 export const DEFAULT_PLAYBACK_STATE: PlaybackState = {

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -1,11 +1,11 @@
-import { createContext, useContext, useState, useEffect, useCallback, useMemo, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react';
 import type {
   AppSettings,
   PlaylistSummary,
   TrackInfo,
   InvalidPlaylistInfo,
 } from '../types';
-import { DEFAULT_SETTINGS, DEFAULT_PLAYBACK_STATE } from '../constants';
+import { DEFAULT_SETTINGS, DEFAULT_PLAYBACK_STATE, normalizeEqualizerGains } from '../constants';
 import {
   initApiService,
   getApiService,
@@ -19,6 +19,7 @@ interface AppContextValue {
   // Settings
   settings: AppSettings;
   updateSettings: (settings: AppSettings) => Promise<void>;
+  setEqualizerGains: (gains: number[]) => void;
 
   // Playlists
   playlists: PlaylistSummary[];
@@ -105,8 +106,23 @@ function AppDataProvider({ children }: AppProviderProps) {
   const isLoading = loadingCount > 0;
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
+  const settingsRef = useRef(settings);
+  const equalizerSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { playerActions } = usePlayer();
+
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
+
+  useEffect(() => {
+    return () => {
+      if (equalizerSaveTimeoutRef.current) {
+        clearTimeout(equalizerSaveTimeoutRef.current);
+        equalizerSaveTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   const setIsLoading = useCallback((loading: boolean) => {
     setLoadingCount(prev => Math.max(0, prev + (loading ? 1 : -1)));
@@ -139,20 +155,26 @@ function AppDataProvider({ children }: AppProviderProps) {
         console.log('[useApp] Storage initialized');
 
         const loadedSettings = await storageService.getSettings(DEFAULT_SETTINGS);
-        console.log('[useApp] Settings loaded:', loadedSettings);
-        setSettings(loadedSettings);
-        initApiService(loadedSettings.serverUrl);
+        const normalizedSettings: AppSettings = {
+          ...loadedSettings,
+          equalizerGains: normalizeEqualizerGains(loadedSettings.equalizerGains),
+        };
+        console.log('[useApp] Settings loaded:', normalizedSettings);
+        setSettings(normalizedSettings);
+        settingsRef.current = normalizedSettings;
+        initApiService(normalizedSettings.serverUrl);
 
         // Apply loaded settings to audio player
-        playerActions.setReplayGainMode(loadedSettings.replayGainMode);
-        playerActions.setReplayGainPreamp(loadedSettings.replayGainPreamp);
-        playerActions.setPreventDownloadOnLowData(loadedSettings.preventDownloadOnLowData);
+        playerActions.setReplayGainMode(normalizedSettings.replayGainMode);
+        playerActions.setReplayGainPreamp(normalizedSettings.replayGainPreamp);
+        playerActions.setEqualizerGains(normalizedSettings.equalizerGains);
+        playerActions.setPreventDownloadOnLowData(normalizedSettings.preventDownloadOnLowData);
 
         const networkType = getNetworkType();
         playerActions.setNetworkType(networkType);
         const quality = networkType === 'low-data'
-          ? loadedSettings.lowDataQuality
-          : loadedSettings.normalQuality;
+          ? normalizedSettings.lowDataQuality
+          : normalizedSettings.normalQuality;
         playerActions.setQuality(quality);
 
         await downloadService.init();
@@ -661,32 +683,73 @@ function AppDataProvider({ children }: AppProviderProps) {
     }
   }
 
+  const setEqualizerGains = useCallback((gains: number[]) => {
+    const normalizedGains = normalizeEqualizerGains(gains);
+    const currentSettings = settingsRef.current;
+    const hasChanged = normalizedGains.some((gain, index) => gain !== currentSettings.equalizerGains[index]);
+    if (!hasChanged) {
+      return;
+    }
+
+    const nextSettings: AppSettings = {
+      ...currentSettings,
+      equalizerGains: normalizedGains,
+    };
+
+    settingsRef.current = nextSettings;
+    setSettings(nextSettings);
+    playerActions.setEqualizerGains(normalizedGains);
+
+    if (equalizerSaveTimeoutRef.current) {
+      clearTimeout(equalizerSaveTimeoutRef.current);
+    }
+
+    equalizerSaveTimeoutRef.current = setTimeout(() => {
+      const settingsSnapshot = settingsRef.current;
+      storageService.saveSettings(settingsSnapshot).catch((error) => {
+        console.error('[useApp] Failed to save equalizer settings:', error);
+      });
+      equalizerSaveTimeoutRef.current = null;
+    }, 250);
+  }, [playerActions]);
+
   const updateSettings = useCallback(async (newSettings: AppSettings) => {
-    console.log('[useApp] updateSettings called with:', newSettings);
-    const serverChanged = newSettings.serverUrl !== settings.serverUrl;
+    const normalizedSettings: AppSettings = {
+      ...newSettings,
+      equalizerGains: normalizeEqualizerGains(newSettings.equalizerGains),
+    };
+    console.log('[useApp] updateSettings called with:', normalizedSettings);
+    const serverChanged = normalizedSettings.serverUrl !== settings.serverUrl;
 
-    setSettings(newSettings);
+    if (equalizerSaveTimeoutRef.current) {
+      clearTimeout(equalizerSaveTimeoutRef.current);
+      equalizerSaveTimeoutRef.current = null;
+    }
+
+    setSettings(normalizedSettings);
+    settingsRef.current = normalizedSettings;
     console.log('[useApp] Calling storageService.saveSettings');
-    await storageService.saveSettings(newSettings);
+    await storageService.saveSettings(normalizedSettings);
     console.log('[useApp] storageService.saveSettings completed');
-    initApiService(newSettings.serverUrl);
+    initApiService(normalizedSettings.serverUrl);
 
-    playerActions.setReplayGainMode(newSettings.replayGainMode);
-    playerActions.setReplayGainPreamp(newSettings.replayGainPreamp);
-    playerActions.setPreventDownloadOnLowData(newSettings.preventDownloadOnLowData);
+    playerActions.setReplayGainMode(normalizedSettings.replayGainMode);
+    playerActions.setReplayGainPreamp(normalizedSettings.replayGainPreamp);
+    playerActions.setEqualizerGains(normalizedSettings.equalizerGains);
+    playerActions.setPreventDownloadOnLowData(normalizedSettings.preventDownloadOnLowData);
 
     const networkType = getNetworkType();
     playerActions.setNetworkType(networkType);
     const quality = networkType === 'low-data'
-      ? newSettings.lowDataQuality
-      : newSettings.normalQuality;
+      ? normalizedSettings.lowDataQuality
+      : normalizedSettings.normalQuality;
     playerActions.setQuality(quality);
 
     showToast('Settings saved');
 
     const downloadQualityChanged =
-      newSettings.downloadQuality.format !== settings.downloadQuality.format ||
-      newSettings.downloadQuality.maxBitRate !== settings.downloadQuality.maxBitRate;
+      normalizedSettings.downloadQuality.format !== settings.downloadQuality.format ||
+      normalizedSettings.downloadQuality.maxBitRate !== settings.downloadQuality.maxBitRate;
 
     if (downloadQualityChanged) {
       await storageService.clearCachedTracks();
@@ -699,7 +762,7 @@ function AppDataProvider({ children }: AppProviderProps) {
       for (const playlistId of offlineIds) {
         const cachedPlaylist = await storageService.getCachedPlaylist(playlistId);
         if (cachedPlaylist && cachedPlaylist.tracks.length > 0) {
-          await downloadService.queuePlaylistDownload(cachedPlaylist.tracks, playlistId, newSettings.downloadQuality);
+          await downloadService.queuePlaylistDownload(cachedPlaylist.tracks, playlistId, normalizedSettings.downloadQuality);
           redownloadCount++;
         }
       }
@@ -709,7 +772,7 @@ function AppDataProvider({ children }: AppProviderProps) {
       }
     }
 
-    if (serverChanged && newSettings.serverUrl) {
+    if (serverChanged && normalizedSettings.serverUrl) {
       setIsLoading(true);
       try {
         await syncPlaylistsInternal();
@@ -989,6 +1052,7 @@ function AppDataProvider({ children }: AppProviderProps) {
   const value = useMemo<AppContextValue>(() => ({
     settings,
     updateSettings,
+    setEqualizerGains,
     playlists,
     currentPlaylistId,
     currentPlaylistTracks,
@@ -1019,6 +1083,7 @@ function AppDataProvider({ children }: AppProviderProps) {
   }), [
     settings,
     updateSettings,
+    setEqualizerGains,
     playlists,
     currentPlaylistId,
     currentPlaylistTracks,

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useAudioPlayer.ts
@@ -38,6 +38,7 @@ export interface AudioPlayerActions {
   setQuality: (quality: StreamingQuality) => void;
   setReplayGainMode: (mode: ReplayGainMode) => void;
   setReplayGainPreamp: (preamp: number) => void;
+  setEqualizerGains: (gains: number[]) => void;
   setScrobbleEnabled: (enabled: boolean) => void;
   setPreventDownloadOnLowData: (prevent: boolean) => void;
   setNetworkType: (type: 'normal' | 'low-data' | 'unknown') => void;
@@ -191,6 +192,9 @@ export function useAudioPlayer(): [AudioPlayerState, AudioPlayerActions] {
     },
     setReplayGainPreamp: (preamp: number) => {
       audioPlayer.setReplayGainPreamp(preamp);
+    },
+    setEqualizerGains: (gains: number[]) => {
+      audioPlayer.setEqualizerGains(gains);
     },
     setScrobbleEnabled: (enabled: boolean) => {
       audioPlayer.setScrobbleEnabled(enabled);

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AudioPlayerService } from './audio-player';
 import { TrackInfo } from '../types';
+import { EQUALIZER_FREQUENCIES } from '../constants';
 
 // Mock dependencies
 vi.mock('./api-service', () => ({
@@ -257,6 +258,30 @@ describe('AudioPlayerService Queue Logic', () => {
 
       player.toggleMute();
       expect(audioAfterPlay.muted).toBe(false);
+    });
+  });
+
+  describe('Equalizer', () => {
+    it('should apply configured band gains when AudioContext is initialized', async () => {
+      const expectedGains = EQUALIZER_FREQUENCIES.map((_frequency, index) => index - 4);
+      player.setEqualizerGains(expectedGains);
+
+      await player.play();
+
+      const equalizerNodes = (player as any).equalizerNodes as BiquadFilterNode[];
+      expect(equalizerNodes).toHaveLength(EQUALIZER_FREQUENCIES.length);
+
+      for (let i = 0; i < EQUALIZER_FREQUENCIES.length; i++) {
+        expect(equalizerNodes[i].frequency.value).toBe(EQUALIZER_FREQUENCIES[i]);
+        expect(equalizerNodes[i].gain.value).toBe(expectedGains[i]);
+      }
+    });
+
+    it('should clamp out-of-range equalizer values', () => {
+      player.setEqualizerGains([30, -30]);
+
+      expect(player.getEqualizerGains()[0]).toBe(12);
+      expect(player.getEqualizerGains()[1]).toBe(-12);
     });
   });
 

--- a/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/audio-player.ts
@@ -1,4 +1,5 @@
 import type { TrackInfo, StreamingQuality, ReplayGainMode, PlaybackState, RepeatMode, QueueItem } from '../types';
+import { EQUALIZER_FREQUENCIES, normalizeEqualizerGains } from '../constants';
 import { getApiService } from './api-service';
 import { storageService } from './storage-service';
 import { PlayQueueService } from './play-queue-service';
@@ -52,6 +53,8 @@ export class AudioPlayerService {
   private quality: StreamingQuality = { format: 'raw' };
   private replayGainMode: ReplayGainMode = 'off';
   private replayGainPreamp: number = 0;
+  private equalizerGains: number[] = normalizeEqualizerGains(null);
+  private equalizerNodes: BiquadFilterNode[] = [];
   private preventDownloadOnLowData: boolean = false;
   private networkType: 'normal' | 'low-data' | 'unknown' = 'unknown';
   private cachedTrackIds: Set<string> = new Set();
@@ -138,6 +141,7 @@ export class AudioPlayerService {
 
     this.audioContext = new AudioContext();
     this.masterGainNode = this.audioContext.createGain();
+    this.initEqualizerNodes();
     this.masterGainNode.connect(this.audioContext.destination);
 
     // Connect audio element to the audio context
@@ -150,12 +154,47 @@ export class AudioPlayerService {
   }
 
   private connectAudioInstance(instance: AudioInstance): void {
-    if (!this.audioContext || !this.masterGainNode) return;
+    if (!this.audioContext) return;
+
+    const outputNode = this.getTrackOutputNode();
+    if (!outputNode) return;
 
     instance.gainNode = this.audioContext.createGain();
     instance.sourceNode = this.audioContext.createMediaElementSource(instance.audio);
     instance.sourceNode.connect(instance.gainNode);
-    instance.gainNode.connect(this.masterGainNode);
+    instance.gainNode.connect(outputNode);
+  }
+
+  private initEqualizerNodes(): void {
+    const audioContext = this.audioContext;
+    if (!audioContext || !this.masterGainNode) return;
+
+    this.equalizerNodes = EQUALIZER_FREQUENCIES.map((frequency, index) => {
+      const filter = audioContext.createBiquadFilter();
+      filter.type = 'peaking';
+      filter.frequency.value = frequency;
+      filter.Q.value = 1;
+      filter.gain.value = this.equalizerGains[index] ?? 0;
+      return filter;
+    });
+
+    for (let i = 0; i < this.equalizerNodes.length - 1; i++) {
+      this.equalizerNodes[i].connect(this.equalizerNodes[i + 1]);
+    }
+
+    this.equalizerNodes[this.equalizerNodes.length - 1]?.connect(this.masterGainNode);
+  }
+
+  private getTrackOutputNode(): AudioNode | null {
+    if (!this.masterGainNode) return null;
+    return this.equalizerNodes[0] ?? this.masterGainNode;
+  }
+
+  private applyEqualizerGains(): void {
+    for (let i = 0; i < this.equalizerNodes.length; i++) {
+      const gainValue = this.equalizerGains[i] ?? 0;
+      this.equalizerNodes[i].gain.value = gainValue;
+    }
   }
 
   private setupAudioEvents(instance: AudioInstance): void {
@@ -1058,6 +1097,15 @@ export class AudioPlayerService {
     this.applyReplayGain(this.activeInstance);
   }
 
+  setEqualizerGains(gains: readonly number[]): void {
+    this.equalizerGains = normalizeEqualizerGains(gains);
+    this.applyEqualizerGains();
+  }
+
+  getEqualizerGains(): number[] {
+    return [...this.equalizerGains];
+  }
+
   setPreventDownloadOnLowData(prevent: boolean): void {
     this.preventDownloadOnLowData = prevent;
   }
@@ -1207,6 +1255,7 @@ export class AudioPlayerService {
       URL.revokeObjectURL(this.preloadBlobUrl);
       this.preloadBlobUrl = null;
     }
+    this.equalizerNodes = [];
     this.teardownVisibilityHandling();
   }
 }

--- a/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
@@ -53,6 +53,16 @@ class MockAudioContext {
     };
   }
 
+  createBiquadFilter() {
+    return {
+      connect: vi.fn(),
+      gain: { value: 0 },
+      frequency: { value: 0 },
+      Q: { value: 1 },
+      type: 'peaking' as BiquadFilterType,
+    };
+  }
+
   async resume() {
     return undefined;
   }

--- a/Meziantou.MusicApp.WebPlayer/src/styles/main.css
+++ b/Meziantou.MusicApp.WebPlayer/src/styles/main.css
@@ -1081,6 +1081,73 @@ body {
   gap: 4px;
 }
 
+.player-equalizer {
+  position: relative;
+}
+
+.equalizer-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 12px);
+  width: 260px;
+  padding: 12px;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-lg);
+  z-index: 220;
+}
+
+.equalizer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-size: 13px;
+}
+
+.equalizer-reset-button {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.equalizer-reset-button:hover {
+  color: var(--text-primary);
+}
+
+.equalizer-bands {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.equalizer-band {
+  display: grid;
+  grid-template-columns: 36px 1fr 52px;
+  align-items: center;
+  gap: 8px;
+}
+
+.equalizer-frequency {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.equalizer-slider {
+  width: 100%;
+}
+
+.equalizer-gain {
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 .volume-btn .hidden {
   display: none;
 }
@@ -1540,6 +1607,11 @@ body {
   
   .player-volume {
     display: none;
+  }
+
+  .equalizer-popover {
+    right: -12px;
+    width: min(280px, 92vw);
   }
   
   .track-list-header {

--- a/Meziantou.MusicApp.WebPlayer/src/types/app.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/types/app.ts
@@ -16,6 +16,7 @@ export interface AppSettings {
   replayGainMode: ReplayGainMode;
   replayGainPreamp: number; // in dB
   showReplayGainWarning: boolean;
+  equalizerGains: number[]; // 10-band equalizer gains in dB
 }
 
 export interface StreamingQuality {

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A modern, web-based music player designed to work with the server. Features incl
 - Offline mode with caching
 - Dark theme
 - Background sync and auto-resume
+- 10-band equalizer in the player bar
 - macOS desktop wrapper using Tauri
 
 ## Getting Started


### PR DESCRIPTION
## Why
The WebPlayer needed an integrated equalizer so listeners can tune playback in real time without leaving the playing controls. This adds a 10-band EQ that is preserved across app restarts and applied directly in the audio pipeline.

## What changed
- Added an equalizer toggle button in the player bar with a popover containing 10 labeled sliders (31Hz to 16kHz) and a reset action.
- Extended app settings with `equalizerGains`, including defaults and normalization/clamping for safe backward-compatible loading.
- Added a dedicated equalizer update path in app state that applies changes immediately and persists them with a short debounce while dragging.
- Updated `AudioPlayerService` to build and wire a 10-band `BiquadFilterNode` peaking chain between per-track gain and master output gain.
- Updated tests and test mocks to cover equalizer behavior and UI rendering.
- Updated root and WebPlayer README files to document the new equalizer feature.

## Notes for reviewers
- Equalizer gains are clamped to `-12 dB` to `+12 dB` and normalized to exactly 10 bands.
- Settings persistence for slider drags is intentionally debounced to reduce IndexedDB write pressure.

## Validation
- `cd Meziantou.MusicApp.WebPlayer && npm test`
- `cd Meziantou.MusicApp.WebPlayer && npm run build`
- `dotnet test`