### PR TITLE
Show library scan progression in settings dialog

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.test.tsx
@@ -1,0 +1,112 @@
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '../constants';
+import { SettingsDialog } from './SettingsDialog';
+
+const useAppMock = vi.fn();
+const useServiceWorkerUpdateMock = vi.fn();
+const getScanStatusMock = vi.fn();
+
+vi.mock('../hooks', () => ({
+  useApp: () => useAppMock(),
+  useServiceWorkerUpdate: () => useServiceWorkerUpdateMock(),
+}));
+
+vi.mock('../services', () => ({
+  getApiService: vi.fn(() => ({
+    getScanStatus: getScanStatusMock,
+  })),
+}));
+
+describe('SettingsDialog', () => {
+  beforeEach(() => {
+    useAppMock.mockReturnValue({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        serverUrl: 'https://example.test',
+      },
+      updateSettings: vi.fn().mockResolvedValue(undefined),
+      testConnection: vi.fn().mockResolvedValue(true),
+      triggerLibraryScan: vi.fn().mockResolvedValue(undefined),
+      cleanupTranscodingCache: vi.fn().mockResolvedValue(undefined),
+      isOnline: true,
+    });
+
+    useServiceWorkerUpdateMock.mockReturnValue({
+      checkForUpdate: vi.fn().mockResolvedValue(true),
+      needRefresh: false,
+      updateServiceWorker: vi.fn(),
+    });
+  });
+
+  it('shows scan progression when the server is scanning', async () => {
+    getScanStatusMock.mockResolvedValue({
+      isScanning: true,
+      isInitialScanCompleted: true,
+      scanCount: 12,
+      lastScanDate: '2026-01-02T12:00:00Z',
+      percentage: 42,
+      estimatedCompletionTime: '2026-01-02T12:15:00Z',
+      invalidPlaylists: [],
+    });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SettingsDialog
+          isOpen
+          onClose={() => undefined}
+          onOpenDiagnostics={() => undefined}
+        />,
+      );
+    });
+
+    expect(container.querySelector('.scan-progress')).not.toBeNull();
+    expect(container).toHaveTextContent('Library scan in progress');
+    expect(container).toHaveTextContent('42%');
+    expect(container).toHaveTextContent('Estimated completion:');
+    expect(container.querySelector('.scan-progress-bar')).not.toHaveClass('indeterminate');
+    expect(container.querySelector('[role="progressbar"]')).toHaveAttribute('aria-valuenow', '42');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('shows an indeterminate progress indicator when the scan percentage is unknown', async () => {
+    getScanStatusMock.mockResolvedValue({
+      isScanning: true,
+      isInitialScanCompleted: true,
+      scanCount: 12,
+      lastScanDate: '2026-01-02T12:00:00Z',
+      percentage: null,
+      estimatedCompletionTime: null,
+      invalidPlaylists: [],
+    });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SettingsDialog
+          isOpen
+          onClose={() => undefined}
+          onOpenDiagnostics={() => undefined}
+        />,
+      );
+    });
+
+    expect(container.querySelector('.scan-progress')).not.toBeNull();
+    expect(container).toHaveTextContent('In progress');
+    expect(container.querySelector('.scan-progress-bar')).toHaveClass('indeterminate');
+    expect(container.querySelector('[role="progressbar"]')).not.toHaveAttribute('aria-valuenow');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { AppSettings, StreamingQuality, ReplayGainMode } from '../types';
+import type { AppSettings, StreamingQuality, ReplayGainMode, ScanStatusResponse } from '../types';
 import { DEFAULT_SETTINGS } from '../constants';
 import { useApp, useServiceWorkerUpdate } from '../hooks';
 import { getApiService } from '../services';
@@ -35,6 +35,7 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
   const [formData, setFormData] = useState<AppSettings>(settings);
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [scanStatus, setScanStatus] = useState<'idle' | 'scanning' | 'force-scanning'>('idle');
+  const [scanDetails, setScanDetails] = useState<ScanStatusResponse | null>(null);
   const [lastScanDate, setLastScanDate] = useState<string | null>(null);
   const [isLoadingScanStatus, setIsLoadingScanStatus] = useState(false);
   const [cacheCleanupStatus, setCacheCleanupStatus] = useState<'idle' | 'cleaning'>('idle');
@@ -61,6 +62,7 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
 
   const loadScanStatus = useCallback(async () => {
     if (!settings.serverUrl || !isOnline) {
+      setScanDetails(null);
       setLastScanDate(null);
       return;
     }
@@ -69,6 +71,7 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
     try {
       const api = getApiService();
       const status = await api.getScanStatus();
+      setScanDetails(status);
       setLastScanDate(status.lastScanDate);
     } catch (error) {
       console.error('Failed to load scan status:', error);
@@ -83,7 +86,19 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
     }
 
     void loadScanStatus();
-  }, [isOpen, loadScanStatus]);
+
+    if (!settings.serverUrl || !isOnline) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void loadScanStatus();
+    }, 2000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [isOnline, isOpen, loadScanStatus, settings.serverUrl]);
 
   if (!isOpen) return null;
 
@@ -105,6 +120,34 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
       minute: '2-digit',
     });
   };
+
+  const formatEstimatedCompletionTime = (dateStr: string | null): string | null => {
+    if (!dateStr) {
+      return null;
+    }
+
+    const date = new Date(dateStr);
+    if (Number.isNaN(date.getTime())) {
+      return dateStr;
+    }
+
+    return date.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const isServerScanning = scanDetails?.isScanning ?? false;
+  const isScanActionRunning = scanStatus !== 'idle';
+  const isAnyScanRunning = isScanActionRunning || isServerScanning;
+  const scanPercentage = typeof scanDetails?.percentage === 'number'
+    ? Math.max(0, Math.min(100, scanDetails.percentage))
+    : null;
+  const roundedScanPercentage = scanPercentage === null ? null : Math.round(scanPercentage);
+  const estimatedCompletionTime = formatEstimatedCompletionTime(scanDetails?.estimatedCompletionTime ?? null);
 
   const getQualityIndex = (quality: StreamingQuality): number => {
     return QUALITY_OPTIONS.findIndex(
@@ -425,24 +468,61 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
                   <button
                     className="secondary-button"
                     onClick={handleRescanLibrary}
-                    disabled={scanStatus !== 'idle'}
+                    disabled={isAnyScanRunning}
                     style={{ flex: 1, marginBottom: '8px' }}
                   >
-                    {scanStatus === 'scanning' ? 'Scanning...' : 'Rescan Music Library'}
+                    {scanStatus === 'scanning'
+                      ? 'Scanning...'
+                      : isServerScanning
+                        ? 'Scan in Progress...'
+                        : 'Rescan Music Library'}
                   </button>
                   <small style={{ marginBottom: '8px', whiteSpace: 'nowrap' }}>
                     Last scan: {isLoadingScanStatus ? 'Loading...' : formatLastScanDate(lastScanDate)}
                   </small>
                 </div>
               </div>
+              {isServerScanning && (
+                <div className="form-group">
+                  <div className="scan-progress" role="status" aria-live="polite">
+                    <div className="scan-progress-header">
+                      <span>Library scan in progress</span>
+                      <span>{roundedScanPercentage === null ? 'In progress' : `${roundedScanPercentage}%`}</span>
+                    </div>
+                    <div
+                      className={`scan-progress-bar ${roundedScanPercentage === null ? 'indeterminate' : ''}`}
+                      role="progressbar"
+                      aria-label="Library scan progress"
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={roundedScanPercentage ?? undefined}
+                      aria-valuetext={roundedScanPercentage === null ? 'In progress' : `${roundedScanPercentage}%`}
+                    >
+                      <div
+                        className="scan-progress-fill"
+                        style={roundedScanPercentage === null ? undefined : { width: `${roundedScanPercentage}%` }}
+                      />
+                    </div>
+                    <small>
+                      {estimatedCompletionTime
+                        ? `Estimated completion: ${estimatedCompletionTime}`
+                        : 'Estimated completion time unavailable'}
+                    </small>
+                  </div>
+                </div>
+              )}
               <div className="form-group">
                 <button
                   className="secondary-button"
                   onClick={handleForceRescanLibrary}
-                  disabled={scanStatus !== 'idle'}
+                  disabled={isAnyScanRunning}
                   style={{ width: '100%', marginBottom: '8px' }}
                 >
-                  {scanStatus === 'force-scanning' ? 'Force Scanning...' : 'Force Rescan (Ignore Cache)'}
+                  {scanStatus === 'force-scanning'
+                    ? 'Force Scanning...'
+                    : isServerScanning
+                      ? 'Scan in Progress...'
+                      : 'Force Rescan (Ignore Cache)'}
                 </button>
               </div>
               <div className="form-group">

--- a/Meziantou.MusicApp.WebPlayer/src/styles/main.css
+++ b/Meziantou.MusicApp.WebPlayer/src/styles/main.css
@@ -1440,6 +1440,66 @@ body {
   color: var(--error);
 }
 
+.scan-progress {
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  background: var(--bg-tertiary);
+}
+
+.scan-progress-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.scan-progress-header span:last-child {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.scan-progress-bar {
+  position: relative;
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--bg-primary);
+}
+
+.scan-progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent-gradient);
+  transition: width var(--transition-fast);
+}
+
+.scan-progress-bar.indeterminate .scan-progress-fill {
+  width: 35%;
+  animation: scan-progress-indeterminate 1.4s ease-in-out infinite;
+}
+
+@keyframes scan-progress-indeterminate {
+  0% {
+    transform: translateX(-140%);
+  }
+
+  50% {
+    transform: translateX(30%);
+  }
+
+  100% {
+    transform: translateX(220%);
+  }
+}
+
+.scan-progress small {
+  margin-top: 8px;
+}
+
 /* Buttons */
 .primary-button,
 .secondary-button {


### PR DESCRIPTION
## Why
When a library scan is running on the server, the settings dialog only showed start actions and the last scan timestamp. Users had no visibility into ongoing progress.

## What changed
- Updated `SettingsDialog` to fetch scan status when opened and poll it every 2 seconds while the dialog stays open.
- Added a scan progress panel in Advanced settings when a server scan is active.
  - Shows determinate progress when `percentage` is provided.
  - Falls back to an indeterminate progress bar when `percentage` is unavailable.
  - Shows estimated completion time when available.
- Kept rescan actions safe by disabling both scan buttons while any scan is already running, including scans started outside the dialog.
- Added `SettingsDialog` tests for both determinate and indeterminate scan-progress states.
- Added dedicated CSS styles and indeterminate animation for the scan-progress UI.

## Notes
- `npm run lint` currently reports `eslint: command not found` in this repository state. This change does not alter lint tooling configuration.