### PR TITLE
Remove unused NSubstitute package from server tests

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Meziantou.MusicApp.Server.Tests.csproj
+++ b/Meziantou.MusicApp.Server.Tests/Meziantou.MusicApp.Server.Tests.csproj
@@ -6,7 +6,6 @@
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="5.0.3" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The server test project had a direct dependency on NSubstitute even though no tests use it. Removing the unused package keeps test dependencies lean and avoids restoring an unnecessary library.

## Summary
- Remove `NSubstitute` from `Meziantou.MusicApp.Server.Tests.csproj`.
- Keep all existing test behavior unchanged.

## Validation
- `dotnet build Meziantou.MusicApp.slnx`
- `dotnet test Meziantou.MusicApp.Server.Tests/Meziantou.MusicApp.Server.Tests.csproj --no-build` (138 passed)