### PR TITLE
Reduce WebPlayer dependency surface by removing unused packages

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/package-lock.json
+++ b/Meziantou.MusicApp.WebPlayer/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@testing-library/jest-dom": "6.9.1",
-        "@testing-library/react": "16.3.2",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
@@ -24,8 +23,7 @@
         "typescript": "6.0.3",
         "vite": "8.0.11",
         "vite-plugin-pwa": "1.3.0",
-        "vitest": "4.1.5",
-        "workbox-window": "7.4.1"
+        "vitest": "4.1.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3305,34 +3303,6 @@
         "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {

--- a/Meziantou.MusicApp.WebPlayer/package.json
+++ b/Meziantou.MusicApp.WebPlayer/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "devDependencies": {
     "@testing-library/jest-dom": "6.9.1",
-    "@testing-library/react": "16.3.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
@@ -30,8 +29,7 @@
     "typescript": "6.0.3",
     "vite": "8.0.11",
     "vite-plugin-pwa": "1.3.0",
-    "vitest": "4.1.5",
-    "workbox-window": "7.4.1"
+    "vitest": "4.1.5"
   },
   "dependencies": {
     "idb": "^8.0.3",


### PR DESCRIPTION
## Why
This reduces direct third-party dependencies to lower the supply-chain attack surface while keeping behavior unchanged.

## What changed
- Removed `@testing-library/react` from WebPlayer `devDependencies` because it is not used by the current test suite.
- Removed direct `workbox-window` from WebPlayer `devDependencies`.
- Updated `package-lock.json` to reflect the dependency cleanup.

`workbox-window` is still available transitively through `vite-plugin-pwa`, so PWA-related behavior remains intact.

## Notes
- Kept `xunit.runner.visualstudio` as requested.