### PR TITLE
Reduce WebPlayer third-party dependency surface

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/package-lock.json
+++ b/Meziantou.MusicApp.WebPlayer/package-lock.json
@@ -9,12 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "idb": "^8.0.3",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
       "devDependencies": {
-        "@testing-library/jest-dom": "6.9.1",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
@@ -25,13 +23,6 @@
         "vite-plugin-pwa": "1.3.0",
         "vitest": "4.1.5"
       }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.7",
@@ -3285,26 +3276,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
       "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -3558,16 +3529,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -3959,13 +3920,6 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4121,13 +4075,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4811,22 +4758,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/idb": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
-      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
-      "license": "ISC"
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -5724,16 +5655,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6028,20 +5949,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.6"
-      }
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6796,19 +6703,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/Meziantou.MusicApp.WebPlayer/package.json
+++ b/Meziantou.MusicApp.WebPlayer/package.json
@@ -20,7 +20,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@testing-library/jest-dom": "6.9.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
@@ -32,7 +31,6 @@
     "vitest": "4.1.5"
   },
   "dependencies": {
-    "idb": "^8.0.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   }

--- a/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/CoverImage.test.tsx
@@ -58,7 +58,7 @@ describe('CoverImage', () => {
 
     const image = container.querySelector('img');
     expect(image).not.toBeNull();
-    expect(image).toHaveAttribute('src', expect.stringContaining('data:image/svg+xml'));
+    expect(image?.getAttribute('src')).toContain('data:image/svg+xml');
 
     act(() => {
       root.unmount();

--- a/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/PlayerBar.test.tsx
@@ -77,7 +77,7 @@ describe('PlayerBar', () => {
 
     const element = container.querySelector('[data-testid="player-cover-placeholder-optin"]');
     expect(element).not.toBeNull();
-    expect(element).toHaveTextContent('true');
+    expect(element?.textContent).toContain('true');
 
     act(() => {
       root.unmount();

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.test.tsx
@@ -65,11 +65,11 @@ describe('SettingsDialog', () => {
     });
 
     expect(container.querySelector('.scan-progress')).not.toBeNull();
-    expect(container).toHaveTextContent('Library scan in progress');
-    expect(container).toHaveTextContent('42%');
-    expect(container).toHaveTextContent('Estimated completion:');
-    expect(container.querySelector('.scan-progress-bar')).not.toHaveClass('indeterminate');
-    expect(container.querySelector('[role="progressbar"]')).toHaveAttribute('aria-valuenow', '42');
+    expect(container.textContent).toContain('Library scan in progress');
+    expect(container.textContent).toContain('42%');
+    expect(container.textContent).toContain('Estimated completion:');
+    expect(container.querySelector('.scan-progress-bar')?.classList.contains('indeterminate')).toBe(false);
+    expect(container.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow')).toBe('42');
 
     await act(async () => {
       root.unmount();
@@ -101,9 +101,9 @@ describe('SettingsDialog', () => {
     });
 
     expect(container.querySelector('.scan-progress')).not.toBeNull();
-    expect(container).toHaveTextContent('In progress');
-    expect(container.querySelector('.scan-progress-bar')).toHaveClass('indeterminate');
-    expect(container.querySelector('[role="progressbar"]')).not.toHaveAttribute('aria-valuenow');
+    expect(container.textContent).toContain('In progress');
+    expect(container.querySelector('.scan-progress-bar')?.classList.contains('indeterminate')).toBe(true);
+    expect(container.querySelector('[role="progressbar"]')?.hasAttribute('aria-valuenow')).toBe(false);
 
     await act(async () => {
       root.unmount();

--- a/Meziantou.MusicApp.WebPlayer/src/services/idb-compat.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/idb-compat.ts
@@ -1,0 +1,336 @@
+export interface DBSchema {
+  [storeName: string]: {
+    key: IDBValidKey;
+    value: unknown;
+    indexes?: Record<string, IDBValidKey>;
+  };
+}
+
+type StoreName<TSchema extends DBSchema> = Extract<keyof TSchema, string>;
+
+type StoreValue<TSchema extends DBSchema, TStore extends StoreName<TSchema>> =
+  TSchema[TStore] extends { value: infer TValue } ? TValue : never;
+
+type StoreKey<TSchema extends DBSchema, TStore extends StoreName<TSchema>> =
+  TSchema[TStore] extends { key: infer TKey }
+    ? TKey extends IDBValidKey
+      ? TKey
+      : IDBValidKey
+    : IDBValidKey;
+
+type StoreIndexes<TSchema extends DBSchema, TStore extends StoreName<TSchema>> =
+  TSchema[TStore] extends { indexes: infer TIndexes }
+    ? TIndexes extends Record<string, IDBValidKey>
+      ? TIndexes
+      : Record<string, IDBValidKey>
+    : Record<string, IDBValidKey>;
+
+type StoreIndexName<TSchema extends DBSchema, TStore extends StoreName<TSchema>> = Extract<
+  keyof StoreIndexes<TSchema, TStore>,
+  string
+>;
+
+type StoreIndexKey<
+  TSchema extends DBSchema,
+  TStore extends StoreName<TSchema>,
+  TIndex extends StoreIndexName<TSchema, TStore>,
+> = StoreIndexes<TSchema, TStore>[TIndex];
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener('complete', () => resolve(), { once: true });
+    transaction.addEventListener(
+      'error',
+      () => reject(transaction.error ?? new Error('IndexedDB transaction failed')),
+      { once: true },
+    );
+    transaction.addEventListener(
+      'abort',
+      () => reject(transaction.error ?? new Error('IndexedDB transaction aborted')),
+      { once: true },
+    );
+  });
+}
+
+export interface IDBPCursorWithValue<TValue> {
+  readonly value: TValue;
+  delete(): Promise<void>;
+  update(value: TValue): Promise<void>;
+  continue(): Promise<IDBPCursorWithValue<TValue> | null>;
+}
+
+class CursorWithValue<TValue> implements IDBPCursorWithValue<TValue> {
+  constructor(private readonly cursor: IDBCursorWithValue) {}
+
+  get value(): TValue {
+    return this.cursor.value as TValue;
+  }
+
+  async delete(): Promise<void> {
+    await requestToPromise(this.cursor.delete());
+  }
+
+  async update(value: TValue): Promise<void> {
+    await requestToPromise(this.cursor.update(value));
+  }
+
+  async continue(): Promise<IDBPCursorWithValue<TValue> | null> {
+    const request = this.cursor.request as IDBRequest<IDBCursorWithValue | null>;
+    this.cursor.continue();
+    const nextCursor = await requestToPromise(request);
+    return nextCursor ? new CursorWithValue<TValue>(nextCursor) : null;
+  }
+}
+
+class IDBPIndex<TValue> {
+  constructor(private readonly index: IDBIndex) {}
+
+  async openCursor(
+    query: IDBValidKey | IDBKeyRange | null = null,
+    direction?: IDBCursorDirection,
+  ): Promise<IDBPCursorWithValue<TValue> | null> {
+    const request = direction ? this.index.openCursor(query, direction) : this.index.openCursor(query);
+    const cursor = await requestToPromise(request);
+    return cursor ? new CursorWithValue<TValue>(cursor) : null;
+  }
+}
+
+class IDBPObjectStore<TValue> {
+  constructor(private readonly store: IDBObjectStore) {}
+
+  get indexNames(): DOMStringList {
+    return this.store.indexNames;
+  }
+
+  createIndex(name: string, keyPath: string | string[], options?: IDBIndexParameters): IDBIndex {
+    return this.store.createIndex(name, keyPath, options);
+  }
+
+  deleteIndex(name: string): void {
+    this.store.deleteIndex(name);
+  }
+
+  async get<TKey extends IDBValidKey>(key: TKey): Promise<TValue | undefined> {
+    return (await requestToPromise(this.store.get(key))) as TValue | undefined;
+  }
+
+  async put<TKey extends IDBValidKey>(value: TValue, key?: TKey): Promise<void> {
+    const request = key === undefined ? this.store.put(value) : this.store.put(value, key);
+    await requestToPromise(request);
+  }
+
+  async add<TKey extends IDBValidKey>(value: TValue, key?: TKey): Promise<void> {
+    const request = key === undefined ? this.store.add(value) : this.store.add(value, key);
+    await requestToPromise(request);
+  }
+
+  async delete<TKey extends IDBValidKey>(key: TKey): Promise<void> {
+    await requestToPromise(this.store.delete(key));
+  }
+
+  async clear(): Promise<void> {
+    await requestToPromise(this.store.clear());
+  }
+
+  async getAll(): Promise<TValue[]> {
+    return (await requestToPromise(this.store.getAll())) as TValue[];
+  }
+
+  async getAllKeys<TKey extends IDBValidKey>(): Promise<TKey[]> {
+    return (await requestToPromise(this.store.getAllKeys())) as TKey[];
+  }
+
+  async count(): Promise<number> {
+    return await requestToPromise(this.store.count());
+  }
+
+  index(name: string): IDBPIndex<TValue> {
+    return new IDBPIndex<TValue>(this.store.index(name));
+  }
+
+  async openCursor(
+    query: IDBValidKey | IDBKeyRange | null = null,
+    direction?: IDBCursorDirection,
+  ): Promise<IDBPCursorWithValue<TValue> | null> {
+    const request = direction ? this.store.openCursor(query, direction) : this.store.openCursor(query);
+    const cursor = await requestToPromise(request);
+    return cursor ? new CursorWithValue<TValue>(cursor) : null;
+  }
+}
+
+class IDBPTransaction<TSchema extends DBSchema, TStore extends StoreName<TSchema>> {
+  public readonly store: IDBPObjectStore<StoreValue<TSchema, TStore>>;
+  public readonly done: Promise<void>;
+
+  constructor(
+    private readonly transaction: IDBTransaction,
+    storeName: TStore,
+  ) {
+    this.store = new IDBPObjectStore<StoreValue<TSchema, TStore>>(this.transaction.objectStore(storeName));
+    this.done = transactionDone(this.transaction);
+  }
+
+  objectStore<TRequestedStore extends StoreName<TSchema>>(
+    storeName: TRequestedStore,
+  ): IDBPObjectStore<StoreValue<TSchema, TRequestedStore>> {
+    return new IDBPObjectStore<StoreValue<TSchema, TRequestedStore>>(this.transaction.objectStore(storeName));
+  }
+}
+
+export class IDBPDatabase<TSchema extends DBSchema> {
+  constructor(private readonly database: IDBDatabase) {}
+
+  get name(): string {
+    return this.database.name;
+  }
+
+  get version(): number {
+    return this.database.version;
+  }
+
+  async get<TStore extends StoreName<TSchema>>(
+    storeName: TStore,
+    key: StoreKey<TSchema, TStore>,
+  ): Promise<StoreValue<TSchema, TStore> | undefined> {
+    const transaction = this.database.transaction(storeName, 'readonly');
+    const result = (await requestToPromise(
+      transaction.objectStore(storeName).get(key),
+    )) as StoreValue<TSchema, TStore> | undefined;
+    await transactionDone(transaction);
+    return result;
+  }
+
+  async put<TStore extends StoreName<TSchema>>(
+    storeName: TStore,
+    value: StoreValue<TSchema, TStore>,
+    key?: StoreKey<TSchema, TStore>,
+  ): Promise<void> {
+    const transaction = this.database.transaction(storeName, 'readwrite');
+    const store = transaction.objectStore(storeName);
+    const request = key === undefined ? store.put(value) : store.put(value, key);
+    await requestToPromise(request);
+    await transactionDone(transaction);
+  }
+
+  async add<TStore extends StoreName<TSchema>>(
+    storeName: TStore,
+    value: StoreValue<TSchema, TStore>,
+    key?: StoreKey<TSchema, TStore>,
+  ): Promise<void> {
+    const transaction = this.database.transaction(storeName, 'readwrite');
+    const store = transaction.objectStore(storeName);
+    const request = key === undefined ? store.add(value) : store.add(value, key);
+    await requestToPromise(request);
+    await transactionDone(transaction);
+  }
+
+  async delete<TStore extends StoreName<TSchema>>(
+    storeName: TStore,
+    key: StoreKey<TSchema, TStore>,
+  ): Promise<void> {
+    const transaction = this.database.transaction(storeName, 'readwrite');
+    await requestToPromise(transaction.objectStore(storeName).delete(key));
+    await transactionDone(transaction);
+  }
+
+  async clear<TStore extends StoreName<TSchema>>(storeName: TStore): Promise<void> {
+    const transaction = this.database.transaction(storeName, 'readwrite');
+    await requestToPromise(transaction.objectStore(storeName).clear());
+    await transactionDone(transaction);
+  }
+
+  async getAll<TStore extends StoreName<TSchema>>(storeName: TStore): Promise<StoreValue<TSchema, TStore>[]> {
+    const transaction = this.database.transaction(storeName, 'readonly');
+    const result = (await requestToPromise(
+      transaction.objectStore(storeName).getAll(),
+    )) as StoreValue<TSchema, TStore>[];
+    await transactionDone(transaction);
+    return result;
+  }
+
+  async getAllKeys<TStore extends StoreName<TSchema>>(storeName: TStore): Promise<StoreKey<TSchema, TStore>[]> {
+    const transaction = this.database.transaction(storeName, 'readonly');
+    const result = (await requestToPromise(
+      transaction.objectStore(storeName).getAllKeys(),
+    )) as StoreKey<TSchema, TStore>[];
+    await transactionDone(transaction);
+    return result;
+  }
+
+  async getAllFromIndex<
+    TStore extends StoreName<TSchema>,
+    TIndex extends StoreIndexName<TSchema, TStore>,
+  >(
+    storeName: TStore,
+    indexName: TIndex,
+    query: StoreIndexKey<TSchema, TStore, TIndex>,
+  ): Promise<StoreValue<TSchema, TStore>[]> {
+    const transaction = this.database.transaction(storeName, 'readonly');
+    const result = (await requestToPromise(
+      transaction.objectStore(storeName).index(indexName).getAll(query),
+    )) as StoreValue<TSchema, TStore>[];
+    await transactionDone(transaction);
+    return result;
+  }
+
+  async count<TStore extends StoreName<TSchema>>(storeName: TStore): Promise<number> {
+    const transaction = this.database.transaction(storeName, 'readonly');
+    const result = await requestToPromise(transaction.objectStore(storeName).count());
+    await transactionDone(transaction);
+    return result;
+  }
+
+  transaction<TStore extends StoreName<TSchema>>(
+    storeName: TStore,
+    mode: IDBTransactionMode,
+  ): IDBPTransaction<TSchema, TStore> {
+    return new IDBPTransaction<TSchema, TStore>(this.database.transaction(storeName, mode), storeName);
+  }
+}
+
+interface OpenDBOptions {
+  upgrade?: (
+    database: IDBDatabase,
+    oldVersion: number,
+    newVersion: number | null,
+    transaction: IDBTransaction,
+  ) => void;
+}
+
+export function openDB<TSchema extends DBSchema>(
+  name: string,
+  version: number,
+  options?: OpenDBOptions,
+): Promise<IDBPDatabase<TSchema>> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(name, version);
+
+    request.onupgradeneeded = event => {
+      if (!options?.upgrade) return;
+      const transaction = request.transaction;
+      if (!transaction) return;
+
+      try {
+        options.upgrade(request.result, event.oldVersion, event.newVersion, transaction);
+      } catch (error) {
+        transaction.abort();
+        reject(error);
+      }
+    };
+
+    request.onsuccess = () => {
+      resolve(new IDBPDatabase<TSchema>(request.result));
+    };
+
+    request.onerror = () => {
+      reject(request.error ?? new Error(`Failed to open IndexedDB database '${name}'`));
+    };
+  });
+}

--- a/Meziantou.MusicApp.WebPlayer/src/services/storage-service.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/services/storage-service.ts
@@ -1,4 +1,4 @@
-import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+import { openDB, type DBSchema, type IDBPDatabase } from './idb-compat';
 import type {
   AppSettings,
   PlaybackState,
@@ -86,7 +86,7 @@ class StorageService {
     if (this.initPromise) return this.initPromise;
 
     this.initPromise = openDB<MusicPlayerDB>(DB_NAME, DB_VERSION, {
-      async upgrade(db, oldVersion, _newVersion, transaction) {
+      upgrade(db, oldVersion, _newVersion, transaction) {
         console.log('[StorageService] Running upgrade, version:', db.version);
         // Settings store
         if (!db.objectStoreNames.contains('settings')) {
@@ -107,7 +107,7 @@ class StorageService {
           const tracksStore = transaction.objectStore('cachedTracks');
           if (oldVersion < 5) {
             // Clear cache to avoid migration issues with schema change
-            await tracksStore.clear();
+            tracksStore.clear();
             if (tracksStore.indexNames.contains('by-playlist')) {
               tracksStore.deleteIndex('by-playlist');
             }
@@ -122,7 +122,7 @@ class StorageService {
           if (oldVersion < 5) {
             // Clear cached playlists to match cleared tracks
             const playlistsStore = transaction.objectStore('cachedPlaylists');
-            await playlistsStore.clear();
+            playlistsStore.clear();
           }
         }
 
@@ -143,7 +143,7 @@ class StorageService {
           if (oldVersion < 5) {
             // Clear offline playlists to prevent orphaned references
             const offlineStore = transaction.objectStore('offlinePlaylists');
-            await offlineStore.clear();
+            offlineStore.clear();
           }
         }
 

--- a/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/setupTests.ts
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
 // Enable React act() support for createRoot-based tests.


### PR DESCRIPTION
This reduces the WebPlayer supply-chain attack surface by removing low-value external dependencies that were straightforward to replace locally.

## What changed
- Replaced the `idb` runtime dependency with an in-repo IndexedDB compatibility layer (`src/services/idb-compat.ts`) and updated `storage-service.ts` to use it.
- Removed `@testing-library/jest-dom` from dev dependencies.
- Updated test assertions in `CoverImage.test.tsx`, `PlayerBar.test.tsx`, and `SettingsDialog.test.tsx` to use native DOM/property checks so the removed matcher package is no longer required.
- Regenerated `package-lock.json` after dependency removal.

## Notes for reviewers
- The local IndexedDB wrapper implements only the subset of the `idb` API currently used by the app, keeping behavior aligned while avoiding an additional third-party runtime package.
- `idb` still appears in the lockfile as a transitive dependency of other tooling, but it is no longer a direct project dependency.