### PR TITLE
Make PWA shortcuts reuse existing app instance

### DIFF
--- a/Meziantou.MusicApp.WebPlayer/public/manifest.webmanifest
+++ b/Meziantou.MusicApp.WebPlayer/public/manifest.webmanifest
@@ -25,12 +25,40 @@
       "purpose": "any maskable"
     }
   ],
+  "launch_handler": {
+    "client_mode": "focus-existing"
+  },
   "categories": ["music", "entertainment"],
   "shortcuts": [
     {
-      "name": "Open Player",
-      "url": "/",
-      "description": "Open the music player"
+      "name": "Play",
+      "url": "/?action=play",
+      "description": "Resume playback"
+    },
+    {
+      "name": "Pause",
+      "url": "/?action=pause",
+      "description": "Pause playback"
+    },
+    {
+      "name": "Next",
+      "url": "/?action=next",
+      "description": "Skip to next track"
+    },
+    {
+      "name": "Previous",
+      "url": "/?action=previous",
+      "description": "Go to previous track"
+    },
+    {
+      "name": "Volume Up",
+      "url": "/?action=volumeup",
+      "description": "Increase volume"
+    },
+    {
+      "name": "Volume Down",
+      "url": "/?action=volumedown",
+      "description": "Decrease volume"
     }
   ]
 }

--- a/Meziantou.MusicApp.WebPlayer/vite.config.ts
+++ b/Meziantou.MusicApp.WebPlayer/vite.config.ts
@@ -39,6 +39,9 @@ export default defineConfig({
         display: 'standalone',
         orientation: 'any',
         start_url: '/',
+        launch_handler: {
+          client_mode: 'focus-existing',
+        },
         icons: [
           {
             src: 'pwa-192x192.png',


### PR DESCRIPTION
## Why
PWA shortcuts currently launch a URL that can open a separate app window. This change makes shortcut launches target the already running app instance so actions like Play/Pause affect the active player.

## What changed
- Added `launch_handler` with `client_mode: focus-existing` to the Vite-generated web app manifest.
- Added the same `launch_handler` to `public/manifest.webmanifest` for consistency where the static manifest is served.
- Updated static manifest shortcuts to match the existing `/?action=...` actions handled by the app.

## Notes
- `launch_handler` behavior is Chromium-specific; browsers that do not support it will ignore it.

## Validation
- `npm test -- --run`
- `npm run build`