### PR TITLE
Show granular library scan progress

### DIFF
--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -366,6 +366,10 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
             LastScanDate = library.LastScanDate,
             Percentage = library.ScanProgress,
             EstimatedCompletionTime = library.ScanEta,
+            ProcessedFiles = library.ProcessedFiles,
+            TotalFiles = library.TotalFiles,
+            ProcessedPlaylists = library.ProcessedPlaylists,
+            TotalPlaylists = library.TotalPlaylists,
         });
     }
 
@@ -382,6 +386,10 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
             LastScanDate = library.LastScanDate,
             Percentage = library.ScanProgress,
             EstimatedCompletionTime = library.ScanEta,
+            ProcessedFiles = library.ProcessedFiles,
+            TotalFiles = library.TotalFiles,
+            ProcessedPlaylists = library.ProcessedPlaylists,
+            TotalPlaylists = library.TotalPlaylists,
             InvalidPlaylists = library.Catalog.InvalidPlaylists.Select(p => new InvalidPlaylistInfo
             {
                 Path = p.Path,

--- a/Meziantou.MusicApp.Server/Models/RestApi/ScanStatusResponse.cs
+++ b/Meziantou.MusicApp.Server/Models/RestApi/ScanStatusResponse.cs
@@ -8,5 +8,9 @@ public class ScanStatusResponse
     public DateTime? LastScanDate { get; set; }
     public double? Percentage { get; set; }
     public TimeSpan? EstimatedCompletionTime { get; set; }
+    public int? ProcessedFiles { get; set; }
+    public int? TotalFiles { get; set; }
+    public int? ProcessedPlaylists { get; set; }
+    public int? TotalPlaylists { get; set; }
     public List<InvalidPlaylistInfo> InvalidPlaylists { get; set; } = [];
 }

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -25,6 +25,8 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     private int _scanCount;
     private int _processedFilesCount;
     private int _totalFilesToScan;
+    private int _processedPlaylistsCount;
+    private int _totalPlaylistsToScan;
     private DateTime _scanStartTime;
     private CancellationToken _cancellationToken = CancellationToken.None;
 
@@ -53,16 +55,33 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     public Task InitialScanCompleted => _initialScanCompleted.Task;
     public bool IsScanning => _scanSemaphore.CurrentCount is 0;
     public int ScanCount => IsScanning ? _processedFilesCount : _scanCount;
-    public double? ScanProgress => IsScanning && _totalFilesToScan > 0 ? (double)_processedFilesCount / _totalFilesToScan * 100 : null;
+    public int? ProcessedFiles => IsScanning ? _processedFilesCount : null;
+    public int? TotalFiles => IsScanning ? _totalFilesToScan : null;
+    public int? ProcessedPlaylists => IsScanning ? _processedPlaylistsCount : null;
+    public int? TotalPlaylists => IsScanning ? _totalPlaylistsToScan : null;
+    public double? ScanProgress
+    {
+        get
+        {
+            if (!IsScanning)
+                return null;
+            var total = _totalFilesToScan + _totalPlaylistsToScan;
+            if (total <= 0)
+                return null;
+            return (double)(_processedFilesCount + _processedPlaylistsCount) / total * 100;
+        }
+    }
+
     public TimeSpan? ScanEta
     {
         get
         {
-            if (!IsScanning || _processedFilesCount == 0 || _totalFilesToScan == 0)
+            var processedFiles = _processedFilesCount;
+            if (!IsScanning || processedFiles == 0 || _totalFilesToScan == 0)
                 return null;
             var elapsed = DateTime.UtcNow - _scanStartTime;
-            var rate = elapsed.TotalSeconds / _processedFilesCount;
-            var remainingItems = _totalFilesToScan - _processedFilesCount;
+            var rate = elapsed.TotalSeconds / processedFiles;
+            var remainingItems = _totalFilesToScan + _totalPlaylistsToScan - processedFiles - _processedPlaylistsCount;
             return TimeSpan.FromSeconds(rate * remainingItems);
         }
     }
@@ -178,9 +197,13 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             activity?.SetTag("music.library.total_files", files.Length);
 
             var audioFiles = files.Where(f => AudioExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase)).ToArray();
+            var xspfFiles = files.Where(f => XspfPlaylistExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase)).ToArray();
+            var m3uFiles = files.Where(f => M3uPlaylistExtensions.Contains(f.Extension, StringComparer.OrdinalIgnoreCase)).ToArray();
 
             _totalFilesToScan = audioFiles.Length;
             _processedFilesCount = 0;
+            _totalPlaylistsToScan = xspfFiles.Length + m3uFiles.Length;
+            _processedPlaylistsCount = 0;
             _scanStartTime = DateTime.UtcNow;
 
             activity?.SetTag("music.library.audio_files", audioFiles.Length);
@@ -212,37 +235,29 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             // Scan existing XSPF playlists
             using (var playlistActivity = MusicLibraryActivitySource.Instance.StartActivity("ScanXspfPlaylists"))
             {
-                var xspfCount = 0;
-                foreach (var file in files)
+                foreach (var file in xspfFiles)
                 {
-                    if (XspfPlaylistExtensions.Contains(file.Extension, StringComparer.OrdinalIgnoreCase))
-                    {
-                        logger.LogInformation("Scanning XSPF playlist: {Path}", file);
-                        await ScanXspfPlaylist(CreateContext(file));
-                        xspfCount++;
-                    }
+                    logger.LogInformation("Scanning XSPF playlist: {Path}", file);
+                    await ScanXspfPlaylist(CreateContext(file));
+                    Interlocked.Increment(ref _processedPlaylistsCount);
                 }
-                playlistActivity?.SetTag("music.library.xspf_playlists", xspfCount);
+                playlistActivity?.SetTag("music.library.xspf_playlists", xspfFiles.Length);
             }
 
             // Convert M3U/M3U8 files to XSPF format and scan them
             using (var m3uActivity = MusicLibraryActivitySource.Instance.StartActivity("ConvertM3uPlaylists"))
             {
-                var m3uCount = 0;
-                foreach (var file in files)
+                foreach (var file in m3uFiles)
                 {
-                    if (M3uPlaylistExtensions.Contains(file.Extension, StringComparer.OrdinalIgnoreCase))
+                    logger.LogInformation("Converting and scanning M3U playlist: {Path}", file);
+                    var xspfPath = await ConvertM3uToXspf(CreateContext(file));
+                    if (xspfPath != null)
                     {
-                        logger.LogInformation("Converting and scanning M3U playlist: {Path}", file);
-                        var xspfPath = await ConvertM3uToXspf(CreateContext(file));
-                        if (xspfPath != null)
-                        {
-                            await ScanXspfPlaylist(CreateContext(xspfPath.Value));
-                        }
-                        m3uCount++;
+                        await ScanXspfPlaylist(CreateContext(xspfPath.Value));
                     }
+                    Interlocked.Increment(ref _processedPlaylistsCount);
                 }
-                m3uActivity?.SetTag("music.library.m3u_playlists", m3uCount);
+                m3uActivity?.SetTag("music.library.m3u_playlists", m3uFiles.Length);
             }
 
             var cachePath = GetCacheJsonPath();

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.test.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.test.tsx
@@ -48,6 +48,10 @@ describe('SettingsDialog', () => {
       lastScanDate: '2026-01-02T12:00:00Z',
       percentage: 42,
       estimatedCompletionTime: '2026-01-02T12:15:00Z',
+      processedFiles: 500,
+      totalFiles: 1000,
+      processedPlaylists: 2,
+      totalPlaylists: 5,
       invalidPlaylists: [],
     });
 
@@ -67,6 +71,8 @@ describe('SettingsDialog', () => {
     expect(container.querySelector('.scan-progress')).not.toBeNull();
     expect(container.textContent).toContain('Library scan in progress');
     expect(container.textContent).toContain('42%');
+    expect(container.textContent).toContain('500 / 1000');
+    expect(container.textContent).toContain('2 / 5');
     expect(container.textContent).toContain('Estimated completion:');
     expect(container.querySelector('.scan-progress-bar')?.classList.contains('indeterminate')).toBe(false);
     expect(container.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow')).toBe('42');
@@ -84,6 +90,10 @@ describe('SettingsDialog', () => {
       lastScanDate: '2026-01-02T12:00:00Z',
       percentage: null,
       estimatedCompletionTime: null,
+      processedFiles: null,
+      totalFiles: null,
+      processedPlaylists: null,
+      totalPlaylists: null,
       invalidPlaylists: [],
     });
 
@@ -104,6 +114,42 @@ describe('SettingsDialog', () => {
     expect(container.textContent).toContain('In progress');
     expect(container.querySelector('.scan-progress-bar')?.classList.contains('indeterminate')).toBe(true);
     expect(container.querySelector('[role="progressbar"]')?.hasAttribute('aria-valuenow')).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('shows file and playlist counts during scanning', async () => {
+    getScanStatusMock.mockResolvedValue({
+      isScanning: true,
+      isInitialScanCompleted: true,
+      scanCount: 12,
+      lastScanDate: '2026-01-02T12:00:00Z',
+      percentage: 80,
+      estimatedCompletionTime: null,
+      processedFiles: 800,
+      totalFiles: 1000,
+      processedPlaylists: 0,
+      totalPlaylists: 3,
+      invalidPlaylists: [],
+    });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SettingsDialog
+          isOpen
+          onClose={() => undefined}
+          onOpenDiagnostics={() => undefined}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('800 / 1000');
+    expect(container.textContent).toContain('0 / 3');
 
     await act(async () => {
       root.unmount();

--- a/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/components/SettingsDialog.tsx
@@ -503,6 +503,16 @@ export function SettingsDialog({ isOpen, onClose, onOpenDiagnostics }: SettingsD
                         style={roundedScanPercentage === null ? undefined : { width: `${roundedScanPercentage}%` }}
                       />
                     </div>
+                    {scanDetails?.totalFiles !== null && scanDetails?.totalFiles !== undefined && (
+                      <small>
+                        Files: {scanDetails.processedFiles ?? 0} / {scanDetails.totalFiles}
+                      </small>
+                    )}
+                    {scanDetails?.totalPlaylists !== null && scanDetails?.totalPlaylists !== undefined && (
+                      <small>
+                        Playlists: {scanDetails.processedPlaylists ?? 0} / {scanDetails.totalPlaylists}
+                      </small>
+                    )}
                     <small>
                       {estimatedCompletionTime
                         ? `Estimated completion: ${estimatedCompletionTime}`

--- a/Meziantou.MusicApp.WebPlayer/src/types/api.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/types/api.ts
@@ -97,6 +97,10 @@ export interface ScanStatusResponse {
   lastScanDate: string | null;
   percentage: number | null;
   estimatedCompletionTime: string | null;
+  processedFiles: number | null;
+  totalFiles: number | null;
+  processedPlaylists: number | null;
+  totalPlaylists: number | null;
   invalidPlaylists: InvalidPlaylistInfo[];
 }
 


### PR DESCRIPTION
The scan progress UI could sit at 100% for a long time even though the scan was still running. The root cause was that the server only counted audio files in the progress calculation, while playlist scanning and related follow-up work continued afterward.

This updates scan tracking to reflect the real work being done:

- pre-compute and track both audio-file and playlist workloads
- expose processed/total counts for files and playlists in the scan status API
- update the settings dialog to show explicit `N / M` progress for files and playlists instead of relying on a misleading percentage alone
- keep the existing percentage, but derive it from the combined tracked workload so it no longer reaches 100% before playlist processing is done

The UI now makes it clear what phase the scan is in, which should make slow scans much easier to understand and review.