### PR TITLE
Add Activity around CreateCatalog method in ScanMusicLibrary

### DIFF
--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -297,7 +297,11 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
 
             logger.LogInformation("Music library scan finished, updating catalog");
             _cachedSerializableCatalog = library;
-            _catalog = await CreateCatalog(library);
+            using (var catalogActivity = MusicLibraryActivitySource.Instance.StartActivity("CreateCatalog"))
+            {
+                _catalog = await CreateCatalog(library);
+                catalogActivity?.SetTag("music.library.serializable_songs_count", library.Songs.Count);
+            }
             _scanCount = _catalog.Songs.Count;
 
             activity?.SetTag("music.library.songs_count", _catalog.Songs.Count);


### PR DESCRIPTION
## Description

Improves observability of the music library catalog creation process by adding activity telemetry tracking.

## Changes

- Wrapped the `CreateCatalog` call in `ScanMusicLibrary` with `MusicLibraryActivitySource` activity
- Added activity tag to track serializable songs count before catalog creation
- Follows existing telemetry patterns used throughout the service

## Verification

- Build: ✅ Successful
- Tests: ✅ All 138 tests pass