### PR TITLE
Sample very fast ScanMusicFile telemetry spans

### DIFF
--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -50,6 +50,9 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         "Cover.jpeg", "Folder.jpeg", "Front.jpeg", "Album.jpeg",
     ];
 
+    private static readonly TimeSpan FastScanMusicFileDurationThreshold = TimeSpan.FromMilliseconds(5);
+    private const double FastScanMusicFileSamplingRate = 0.10;
+
     public MusicCatalog Catalog => _catalog;
     public bool IsInitialScanCompleted => _initialScanCompleted.Task.IsCompleted;
     public Task InitialScanCompleted => _initialScanCompleted.Task;
@@ -328,6 +331,8 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
 
     private async Task ScanMusicFile(IndexerContext context)
     {
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var hasError = false;
         using var activity = MusicLibraryActivitySource.Instance.StartActivity("ScanMusicFile");
         activity?.SetTag("music.file.path", context.RelativePath);
 
@@ -486,7 +491,20 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         }
         catch (Exception ex)
         {
+            hasError = true;
             logger.LogError(ex, "Error scanning music file: {Path}", context.Path);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+        }
+        finally
+        {
+            if (activity is not null && !hasError)
+            {
+                var duration = Stopwatch.GetElapsedTime(startTimestamp);
+                if (duration < FastScanMusicFileDurationThreshold && Random.Shared.NextDouble() > FastScanMusicFileSamplingRate)
+                {
+                    activity.ActivityTraceFlags = ActivityTraceFlags.None;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Why
`ScanMusicFile` is called for every audio file during library indexing, and many calls complete in a few milliseconds. Recording all of those very fast spans adds telemetry noise and volume without much diagnostic value.

## What changed
This updates `ScanMusicFile` activity handling to downsample successful spans that complete in under 5ms:

- Measures elapsed time for each `ScanMusicFile` activity.
- Keeps full telemetry for slower scans and error cases.
- For successful scans faster than 5ms, keeps about 10% of spans by clearing the recorded trace flag on the rest.

This keeps useful signal for fast-path behavior while reducing high-cardinality, low-value span traffic.