### PR TITLE
Restrict web app deployment triggers

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -7,13 +7,6 @@ on:
     paths:
       - 'Meziantou.MusicApp.WebPlayer/**'
       - '.github/workflows/azure-static-web-apps.yml'
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
-    paths:
-      - 'Meziantou.MusicApp.WebPlayer/**'
-      - '.github/workflows/azure-static-web-apps.yml'
   workflow_dispatch:
 
 concurrency:
@@ -22,7 +15,7 @@ concurrency:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:      
@@ -63,16 +56,3 @@ jobs:
           app_location: "Meziantou.MusicApp.WebPlayer/dist"
           output_location: ""
           skip_app_build: true
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          app_location: "Meziantou.MusicApp.WebPlayer"
-          action: "close"


### PR DESCRIPTION
Stop running Azure Static Web Apps deployment for pull request events and keep deployments limited to pushes on main and manual workflow dispatches.