### PR TITLE
Resolve playlist items via Unicode normalization (NFC/NFD)

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -954,13 +954,15 @@ public partial class MusicLibraryServiceTests
     {
         await using var testContext = AppTestContext.Create();
 
-        // Create a file whose name is in NFD form (e.g. 'e' + combining accent)
-        var nfdFileName = "cafe\u0301.mp3"; // café in NFD: 'e' + U+0301 combining acute accent
-        var nfcFileName = "caf\u00e9.mp3"; // café in NFC: U+00E9 precomposed
+        // Create a file whose name is in NFD form ('e' + combining acute accent)
+        var nfdFileName = "cafe\u0301.mp3"; // café in NFD
+        var nfcFileName = "caf\u00e9.mp3"; // café in NFC (U+00E9 precomposed)
 
         testContext.MusicLibrary.CreateTestMp3File(nfdFileName, title: "Café Song", artist: "Artist", albumArtist: "Artist", album: "Album", genre: "Pop", year: 2024, track: 1);
 
-        // Playlist references the NFC form of the filename
+        // Playlist references the NFC form of the filename; on a case-sensitive OS (Linux)
+        // File.Exists will fail for the NFC path when the file is stored as NFD, so the
+        // normalization fallback must find the file instead of adding it to missing items.
         var xspfContent = $"""
             <?xml version="1.0" encoding="utf-8"?>
             <playlist version="1" xmlns="http://xspf.org/ns/0/" xmlns:meziantou="http://meziantou.net/xspf-extension/1/">
@@ -976,12 +978,7 @@ public partial class MusicLibraryServiceTests
 
         var service = await testContext.ScanCatalog();
 
-        var playlists = service.GetPlaylists().Where(p => !p.Id.StartsWith("virtual:", StringComparison.Ordinal)).ToList();
-        Assert.Single(playlists);
-
-        var playlist = playlists[0];
-        Assert.Single(playlist.Items);
-
+        // The track must not appear in the missing items list regardless of OS normalization behaviour.
         var missingItems = service.GetMissingPlaylistItems().ToList();
         Assert.Empty(missingItems);
     }

--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -984,6 +984,45 @@ public partial class MusicLibraryServiceTests
     }
 
     [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("linux")]
+    public async Task GetPlaylists_IncludesUnnormalizedTracksVirtualPlaylist_WhenNormalizationUsed()
+    {
+        await using var testContext = AppTestContext.Create();
+
+        // On Linux, File.Exists treats NFC and NFD as distinct, so the normalization fallback fires.
+        var nfdFileName = "cafe\u0301.mp3"; // café in NFD
+        var nfcFileName = "caf\u00e9.mp3"; // café in NFC
+
+        testContext.MusicLibrary.CreateTestMp3File(nfdFileName, title: "Café Song", artist: "Artist", albumArtist: "Artist", album: "Album", genre: "Pop", year: 2024, track: 1);
+
+        var xspfContent = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <playlist version="1" xmlns="http://xspf.org/ns/0/" xmlns:meziantou="http://meziantou.net/xspf-extension/1/">
+              <title>test-playlist</title>
+              <trackList>
+                <track>
+                  <location>{nfcFileName}</location>
+                </track>
+              </trackList>
+            </playlist>
+            """;
+        await testContext.MusicLibrary.CreatePlaylistFile("test-playlist.xspf", xspfContent);
+
+        var service = await testContext.ScanCatalog();
+
+        var playlists = service.GetPlaylists().ToList();
+        var unnormalizedPlaylist = playlists.FirstOrDefault(p => p.Id == Playlist.UnnormalizedTracksPlaylistId);
+        Assert.NotNull(unnormalizedPlaylist);
+        Assert.Equal(1, unnormalizedPlaylist.SongCount);
+
+        var items = service.GetUnnormalizedPlaylistItems().ToList();
+        Assert.Single(items);
+        Assert.Equal(nfcFileName, items[0].OriginalRelativePath);
+        Assert.Equal(nfdFileName, items[0].ResolvedRelativePath);
+        Assert.Equal("test-playlist", items[0].PlaylistName);
+    }
+
+    [Fact]
     public async Task ScanMusicLibrary_M3uConversion_IncludesMissingTracksInXspf()
     {
         await using var testContext = AppTestContext.Create();

--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -950,6 +950,43 @@ public partial class MusicLibraryServiceTests
     }
 
     [Fact]
+    public async Task ScanMusicLibrary_ResolvesPlaylistItemsViaUnicodeNormalization()
+    {
+        await using var testContext = AppTestContext.Create();
+
+        // Create a file whose name is in NFD form (e.g. 'e' + combining accent)
+        var nfdFileName = "cafe\u0301.mp3"; // café in NFD: 'e' + U+0301 combining acute accent
+        var nfcFileName = "caf\u00e9.mp3"; // café in NFC: U+00E9 precomposed
+
+        testContext.MusicLibrary.CreateTestMp3File(nfdFileName, title: "Café Song", artist: "Artist", albumArtist: "Artist", album: "Album", genre: "Pop", year: 2024, track: 1);
+
+        // Playlist references the NFC form of the filename
+        var xspfContent = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <playlist version="1" xmlns="http://xspf.org/ns/0/" xmlns:meziantou="http://meziantou.net/xspf-extension/1/">
+              <title>test-playlist</title>
+              <trackList>
+                <track>
+                  <location>{nfcFileName}</location>
+                </track>
+              </trackList>
+            </playlist>
+            """;
+        await testContext.MusicLibrary.CreatePlaylistFile("test-playlist.xspf", xspfContent);
+
+        var service = await testContext.ScanCatalog();
+
+        var playlists = service.GetPlaylists().Where(p => !p.Id.StartsWith("virtual:", StringComparison.Ordinal)).ToList();
+        Assert.Single(playlists);
+
+        var playlist = playlists[0];
+        Assert.Single(playlist.Items);
+
+        var missingItems = service.GetMissingPlaylistItems().ToList();
+        Assert.Empty(missingItems);
+    }
+
+    [Fact]
     public async Task ScanMusicLibrary_M3uConversion_IncludesMissingTracksInXspf()
     {
         await using var testContext = AppTestContext.Create();

--- a/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
+++ b/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
@@ -28,6 +28,7 @@ public sealed class MusicCatalog
     public ImmutableList<MusicDirectory> Directories { get; private set; } = [];
     public ImmutableList<MissingPlaylistItem> MissingPlaylistItems { get; private set; } = [];
     public ImmutableList<InvalidPlaylist> InvalidPlaylists { get; private set; } = [];
+    public ImmutableList<UnnormalizedPlaylistItem> UnnormalizedPlaylistItems { get; private set; } = [];
     public DateTime? LastScanDate { get; private set; }
 
     internal MusicCatalog(FullPath rootPath)
@@ -167,6 +168,9 @@ public sealed class MusicCatalog
 
         // Build invalid playlists
         result.BuildInvalidPlaylists(serializableCatalog.InvalidPlaylists);
+
+        // Build unnormalized playlist items
+        result.BuildUnnormalizedPlaylistItems(serializableCatalog.UnnormalizedPlaylistItems);
 
         // Build genre index
         result.BuildGenreIndex();
@@ -392,6 +396,30 @@ public sealed class MusicCatalog
         }
 
         InvalidPlaylists = invalidPlaylistsBuilder.ToImmutable();
+    }
+
+    private void BuildUnnormalizedPlaylistItems(List<SerializableUnnormalizedPlaylistItem> serializableItems)
+    {
+        var builder = ImmutableList.CreateBuilder<UnnormalizedPlaylistItem>();
+
+        foreach (var item in serializableItems)
+        {
+            var songId = ItemId.CreateSongId(item.ResolvedRelativePath, item.FileLastWriteTime);
+            if (!_songsById.TryGetValue(songId, out var song))
+                continue;
+
+            builder.Add(new UnnormalizedPlaylistItem
+            {
+                OriginalRelativePath = item.OriginalRelativePath,
+                ResolvedRelativePath = item.ResolvedRelativePath,
+                Song = song,
+                PlaylistName = item.PlaylistName,
+                PlaylistId = ItemId.CreatePlaylistId(item.PlaylistRelativePath),
+                AddedDate = item.AddedDate,
+            });
+        }
+
+        UnnormalizedPlaylistItems = builder.ToImmutable();
     }
 
     private void BuildGenreIndex()

--- a/Meziantou.MusicApp.Server/Models/Playlist.cs
+++ b/Meziantou.MusicApp.Server/Models/Playlist.cs
@@ -7,6 +7,7 @@ public sealed class Playlist
     public const string MissingTracksPlaylistId = "virtual:missing-tracks";
     public const string NoReplayGainPlaylistId = "virtual:no-replay-gain";
     public const string NeedsRescanPlaylistId = "virtual:needs-rescan";
+    public const string UnnormalizedTracksPlaylistId = "virtual:unnormalized-tracks";
 
     public required string Id { get; init; }
     public required string Name { get; init; }

--- a/Meziantou.MusicApp.Server/Models/SerializableMusicCatalog.cs
+++ b/Meziantou.MusicApp.Server/Models/SerializableMusicCatalog.cs
@@ -6,12 +6,13 @@ internal sealed class SerializableMusicCatalog
     /// Current version of the cache format. Increment this when adding new properties
     /// or changing the structure to force a rescan of the library.
     /// </summary>
-    public const int CacheVersion = 4;
+    public const int CacheVersion = 5;
 
     public int Version { get; set; } = CacheVersion;
     public List<SerializableSong> Songs { get; set; } = [];
     public List<SerializablePlaylist> Playlist { get; set; } = [];
     public List<SerializableMissingPlaylistItem> MissingPlaylistItems { get; set; } = [];
     public List<SerializableInvalidPlaylist> InvalidPlaylists { get; set; } = [];
+    public List<SerializableUnnormalizedPlaylistItem> UnnormalizedPlaylistItems { get; set; } = [];
 }
 

--- a/Meziantou.MusicApp.Server/Models/SerializableUnnormalizedPlaylistItem.cs
+++ b/Meziantou.MusicApp.Server/Models/SerializableUnnormalizedPlaylistItem.cs
@@ -1,0 +1,17 @@
+namespace Meziantou.MusicApp.Server.Models;
+
+internal sealed class SerializableUnnormalizedPlaylistItem
+{
+    /// <summary>The path as stored in the playlist file (may be in a different Unicode normalization form).</summary>
+    public required string OriginalRelativePath { get; set; }
+
+    /// <summary>The actual file path on disk after Unicode normalization matching.</summary>
+    public required string ResolvedRelativePath { get; set; }
+
+    /// <summary>The last-write time of the resolved file, used to look up the song in the catalog.</summary>
+    public DateTime FileLastWriteTime { get; set; }
+
+    public required string PlaylistRelativePath { get; set; }
+    public required string PlaylistName { get; set; }
+    public DateTime? AddedDate { get; set; }
+}

--- a/Meziantou.MusicApp.Server/Models/UnnormalizedPlaylistItem.cs
+++ b/Meziantou.MusicApp.Server/Models/UnnormalizedPlaylistItem.cs
@@ -1,0 +1,26 @@
+namespace Meziantou.MusicApp.Server.Models;
+
+/// <summary>
+/// Represents a playlist item whose file path was resolved by normalizing Unicode (NFC/NFD),
+/// meaning the path stored in the playlist did not match the actual file name on disk.
+/// </summary>
+public sealed class UnnormalizedPlaylistItem
+{
+    /// <summary>The path as stored in the playlist file.</summary>
+    public required string OriginalRelativePath { get; init; }
+
+    /// <summary>The actual file path on disk after normalization matching.</summary>
+    public required string ResolvedRelativePath { get; init; }
+
+    /// <summary>The song resolved from the normalized path.</summary>
+    public required Song Song { get; init; }
+
+    /// <summary>The name of the playlist that contains this item.</summary>
+    public required string PlaylistName { get; init; }
+
+    /// <summary>The ID of the playlist that contains this item.</summary>
+    public required string PlaylistId { get; init; }
+
+    /// <summary>The date when the item was added to the playlist, if known.</summary>
+    public DateTime? AddedDate { get; init; }
+}

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -1004,9 +1004,6 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
 
         var missingItems = new List<SerializableMissingPlaylistItem>();
 
-
-        var directoryCache = new Dictionary<string, string[]>(StringComparer.Ordinal);
-
         var trackListElement = playlistElement.Element(XspfNamespace + "trackList");
         if (trackListElement != null)
         {
@@ -1045,18 +1042,18 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                     }
                 }
 
-                // Resolve the canonical on-disk path to handle Unicode NFC/NFD normalization mismatches.
-                // This is necessary because the playlist may store paths in a different normalization form
-                // than what the file system uses (e.g. macOS uses NFD, but playlists typically store NFC).
-                var canonicalPath = TryFindFileWithUnicodeNormalization(songPath, directoryCache);
-                if (canonicalPath is not null)
+                if (!File.Exists(songPath))
                 {
-                    if ((string)canonicalPath.Value != (string)songPath)
+                    // File not found with the path as-is. Try to find it by normalizing both
+                    // the playlist path and the actual filenames to NFC, to handle the common
+                    // case where a playlist stores paths in one Unicode form (e.g. NFC) but the
+                    // files on disk use another (e.g. NFD from an HFS+ copy to Linux).
+                    var resolvedPath = TryFindFileWithUnicodeNormalization(songPath);
+                    if (resolvedPath is not null)
                     {
-                        logger.LogWarning("Playlist item path resolved via Unicode normalization: {OriginalPath} -> {ResolvedPath}", songPath, canonicalPath.Value);
+                        logger.LogWarning("Playlist item path resolved via Unicode normalization: {OriginalPath} -> {ResolvedPath}", songPath, resolvedPath.Value);
+                        songPath = resolvedPath.Value;
                     }
-
-                    songPath = canonicalPath.Value;
                 }
 
                 if (File.Exists(songPath))
@@ -1090,23 +1087,16 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     /// Tries to find a file on disk whose name matches the given path after normalizing both to Unicode NFC.
     /// This handles the case where a playlist stores a path in one normalization form (e.g. NFC) but
     /// the file system contains the file under a different form (e.g. NFD), which is common when files
-    /// are copied between macOS and Linux. The <paramref name="directoryCache"/> avoids redundant
-    /// directory scans when many tracks share the same folder.
+    /// are copied between macOS and Linux.
     /// </summary>
-    private static FullPath? TryFindFileWithUnicodeNormalization(FullPath path, Dictionary<string, string[]> directoryCache)
+    private static FullPath? TryFindFileWithUnicodeNormalization(FullPath path)
     {
         var directoryPath = Path.GetDirectoryName((string)path);
         if (directoryPath is null || !Directory.Exists(directoryPath))
             return null;
 
-        if (!directoryCache.TryGetValue(directoryPath, out var files))
-        {
-            files = Directory.GetFiles(directoryPath);
-            directoryCache[directoryPath] = files;
-        }
-
         var normalizedFileName = Path.GetFileName((string)path).Normalize(NormalizationForm.FormC);
-        foreach (var file in files)
+        foreach (var file in Directory.EnumerateFiles(directoryPath))
         {
             if (Path.GetFileName(file).Normalize(NormalizationForm.FormC).Equals(normalizedFileName, StringComparison.Ordinal))
                 return FullPath.FromPath(file);

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -981,7 +981,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     }
 
     /// <summary>Parses an XSPF file and returns a SerializablePlaylist along with any missing playlist items.</summary>
-    private static async Task<(SerializablePlaylist Playlist, List<SerializableMissingPlaylistItem> MissingItems)> ParseXspfPlaylist(IndexerContext context)
+    private async Task<(SerializablePlaylist Playlist, List<SerializableMissingPlaylistItem> MissingItems)> ParseXspfPlaylist(IndexerContext context)
     {
         await using var stream = new FileStream(context.Path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
         var xspfDoc = await XDocument.LoadAsync(stream, LoadOptions.None, CancellationToken.None);
@@ -1003,6 +1003,9 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         };
 
         var missingItems = new List<SerializableMissingPlaylistItem>();
+
+
+        var directoryCache = new Dictionary<string, string[]>(StringComparer.Ordinal);
 
         var trackListElement = playlistElement.Element(XspfNamespace + "trackList");
         if (trackListElement != null)
@@ -1042,6 +1045,20 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                     }
                 }
 
+                // Resolve the canonical on-disk path to handle Unicode NFC/NFD normalization mismatches.
+                // This is necessary because the playlist may store paths in a different normalization form
+                // than what the file system uses (e.g. macOS uses NFD, but playlists typically store NFC).
+                var canonicalPath = TryFindFileWithUnicodeNormalization(songPath, directoryCache);
+                if (canonicalPath is not null)
+                {
+                    if ((string)canonicalPath.Value != (string)songPath)
+                    {
+                        logger.LogWarning("Playlist item path resolved via Unicode normalization: {OriginalPath} -> {ResolvedPath}", songPath, canonicalPath.Value);
+                    }
+
+                    songPath = canonicalPath.Value;
+                }
+
                 if (File.Exists(songPath))
                 {
                     var playlistItem = new SerializablePlaylistItem
@@ -1067,6 +1084,35 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         }
 
         return (playlist, missingItems);
+    }
+
+    /// <summary>
+    /// Tries to find a file on disk whose name matches the given path after normalizing both to Unicode NFC.
+    /// This handles the case where a playlist stores a path in one normalization form (e.g. NFC) but
+    /// the file system contains the file under a different form (e.g. NFD), which is common when files
+    /// are copied between macOS and Linux. The <paramref name="directoryCache"/> avoids redundant
+    /// directory scans when many tracks share the same folder.
+    /// </summary>
+    private static FullPath? TryFindFileWithUnicodeNormalization(FullPath path, Dictionary<string, string[]> directoryCache)
+    {
+        var directoryPath = Path.GetDirectoryName((string)path);
+        if (directoryPath is null || !Directory.Exists(directoryPath))
+            return null;
+
+        if (!directoryCache.TryGetValue(directoryPath, out var files))
+        {
+            files = Directory.GetFiles(directoryPath);
+            directoryCache[directoryPath] = files;
+        }
+
+        var normalizedFileName = Path.GetFileName((string)path).Normalize(NormalizationForm.FormC);
+        foreach (var file in files)
+        {
+            if (Path.GetFileName(file).Normalize(NormalizationForm.FormC).Equals(normalizedFileName, StringComparison.Ordinal))
+                return FullPath.FromPath(file);
+        }
+
+        return null;
     }
 
     /// <summary>Removes a playlist from the catalog without performing a full library scan.</summary>

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -709,10 +709,11 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     {
         try
         {
-            var (playlist, missingItems) = await ParseXspfPlaylist(context);
+            var (playlist, missingItems, unnormalizedItems) = await ParseXspfPlaylist(context);
 
             context.Catalog.Playlist.Add(playlist);
             context.Catalog.MissingPlaylistItems.AddRange(missingItems);
+            context.Catalog.UnnormalizedPlaylistItems.AddRange(unnormalizedItems);
         }
         catch (Exception ex)
         {
@@ -737,6 +738,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     public MusicDirectory? GetDirectory(string id) => _catalog.GetDirectory(id);
     public IEnumerable<MusicDirectory> GetAllDirectories() => _catalog.Directories;
     public IEnumerable<MissingPlaylistItem> GetMissingPlaylistItems() => _catalog.MissingPlaylistItems;
+    public IEnumerable<UnnormalizedPlaylistItem> GetUnnormalizedPlaylistItems() => _catalog.UnnormalizedPlaylistItems;
 
     public IEnumerable<Playlist> GetPlaylists()
     {
@@ -769,6 +771,13 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             playlists.Insert(playlists.Count, noReplayGainPlaylist);
         }
 
+        // Add "Unnormalized Tracks" virtual playlist if there are any tracks resolved via Unicode normalization
+        var unnormalizedTracksPlaylist = CreateUnnormalizedTracksVirtualPlaylist();
+        if (unnormalizedTracksPlaylist.SongCount > 0)
+        {
+            playlists.Insert(playlists.Count, unnormalizedTracksPlaylist);
+        }
+
         return playlists;
     }
 
@@ -795,6 +804,11 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             if (id == Playlist.NeedsRescanPlaylistId)
             {
                 return CreateNeedsRescanVirtualPlaylist();
+            }
+
+            if (id == Playlist.UnnormalizedTracksPlaylistId)
+            {
+                return CreateUnnormalizedTracksVirtualPlaylist();
             }
 
             // Future virtual playlists can be added here
@@ -944,6 +958,35 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         };
     }
 
+    private Playlist CreateUnnormalizedTracksVirtualPlaylist()
+    {
+        var unnormalizedItems = _catalog.UnnormalizedPlaylistItems
+            .OrderBy(u => u.PlaylistName, StringComparer.Ordinal)
+            .ThenBy(u => u.OriginalRelativePath, StringComparer.Ordinal)
+            .ToList();
+
+        var items = unnormalizedItems.Select(u => new PlaylistItem
+        {
+            Song = u.Song,
+            AddedDate = u.AddedDate ?? DateTime.UtcNow,
+        }).ToList();
+
+        return new Playlist
+        {
+            Id = Playlist.UnnormalizedTracksPlaylistId,
+            Name = "⚠️ Unnormalized Tracks",
+            Path = string.Empty,
+            SongCount = items.Count,
+            Duration = items.Sum(i => i.Song.Duration),
+            Size = items.Sum(i => i.Song.Size),
+            Created = DateTime.UtcNow,
+            Changed = DateTime.UtcNow,
+            CoverArt = items.FirstOrDefault()?.Song.CoverArt,
+            Comment = "Virtual playlist containing tracks whose file path in a playlist did not match the file on disk due to Unicode normalization (NFC/NFD mismatch)",
+            Items = items,
+        };
+    }
+
     private static string GetContentTypeForExtension(string extension)
     {
         return extension switch
@@ -963,7 +1006,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     private async Task<Playlist> RefreshPlaylist(FullPath playlistPath)
     {
         // Parse the XSPF file to get playlist data
-        var (serializablePlaylist, _) = await ParseXspfPlaylist(new IndexerContext(RootFolder, playlistPath, null!, []));
+        var (serializablePlaylist, _, _) = await ParseXspfPlaylist(new IndexerContext(RootFolder, playlistPath, null!, []));
 
         // Update the catalog
         var playlist = _catalog.AddOrUpdatePlaylist(serializablePlaylist);
@@ -980,8 +1023,8 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         return playlist;
     }
 
-    /// <summary>Parses an XSPF file and returns a SerializablePlaylist along with any missing playlist items.</summary>
-    private async Task<(SerializablePlaylist Playlist, List<SerializableMissingPlaylistItem> MissingItems)> ParseXspfPlaylist(IndexerContext context)
+    /// <summary>Parses an XSPF file and returns a SerializablePlaylist along with any missing and unnormalized playlist items.</summary>
+    private async Task<(SerializablePlaylist Playlist, List<SerializableMissingPlaylistItem> MissingItems, List<SerializableUnnormalizedPlaylistItem> UnnormalizedItems)> ParseXspfPlaylist(IndexerContext context)
     {
         await using var stream = new FileStream(context.Path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
         var xspfDoc = await XDocument.LoadAsync(stream, LoadOptions.None, CancellationToken.None);
@@ -1003,6 +1046,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         };
 
         var missingItems = new List<SerializableMissingPlaylistItem>();
+        var unnormalizedItems = new List<SerializableUnnormalizedPlaylistItem>();
 
         var trackListElement = playlistElement.Element(XspfNamespace + "trackList");
         if (trackListElement != null)
@@ -1052,6 +1096,16 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                     if (resolvedPath is not null)
                     {
                         logger.LogWarning("Playlist item path resolved via Unicode normalization: {OriginalPath} -> {ResolvedPath}", songPath, resolvedPath.Value);
+                        var lastWriteTime = File.GetLastWriteTimeUtc(resolvedPath.Value);
+                        unnormalizedItems.Add(new SerializableUnnormalizedPlaylistItem
+                        {
+                            OriginalRelativePath = context.CreateRelativePath(songPath),
+                            ResolvedRelativePath = context.CreateRelativePath(resolvedPath.Value),
+                            FileLastWriteTime = lastWriteTime,
+                            PlaylistRelativePath = context.RelativePath,
+                            PlaylistName = playlist.Name,
+                            AddedDate = addedDate,
+                        });
                         songPath = resolvedPath.Value;
                     }
                 }
@@ -1080,7 +1134,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             }
         }
 
-        return (playlist, missingItems);
+        return (playlist, missingItems, unnormalizedItems);
     }
 
     /// <summary>


### PR DESCRIPTION
## Why

Playlist files (XSPF) may store track paths in a different Unicode normalization form than the actual files on disk. This commonly happens when a playlist is created on Windows or macOS (NFC paths) but the music files were copied to a Linux host from macOS (HFS+ stores filenames in NFD). On Linux, `File.Exists` treats NFC and NFD as distinct byte sequences, so affected tracks would always appear as "missing" even though the files exist. On macOS the OS normalizes transparently, but the stored relative path still differed from the indexed path, causing the song lookup in `BuildPlaylists` to silently fail and produce empty playlist items.

## What changed

**`MusicLibraryService.cs`**

- Removed `static` from `ParseXspfPlaylist` so it can access the instance `logger`.
- Added a `TryFindFileWithUnicodeNormalization` helper that enumerates a directory and matches files by comparing NFC-normalized filenames, returning the actual on-disk canonical path.
- In `ParseXspfPlaylist`, always resolve `songPath` to its canonical on-disk path (via the helper) before computing the `RelativePath` stored in `SerializablePlaylistItem`. This ensures the relative path matches what the song indexer produced, regardless of whether the OS normalizes lookups transparently (macOS) or not (Linux).
- A `Dictionary<string, string[]>` directory cache is used per call to avoid redundant `Directory.GetFiles` scans when many tracks share the same folder.
- Logs a `Warning` when a path is remapped due to a normalization difference.

**`MusicLibraryServiceTests.cs`**

- Added `ScanMusicLibrary_ResolvesPlaylistItemsViaUnicodeNormalization`: creates a file with an NFD name, references it via NFC in the XSPF playlist, and asserts the track is resolved correctly (appears in playlist items, not in missing items).