### PR TITLE
Skip startup library rescans when the cache is still fresh

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -237,6 +237,102 @@ public partial class MusicLibraryServiceTests
     }
 
     [Fact]
+    public async Task StartAsync_UsesCachedLibrary_WhenCacheRefreshIntervalHasNotElapsed()
+    {
+        using var tempDir = TemporaryDirectory.Create();
+        var musicPath = tempDir / "music";
+        var cachePath = tempDir / "cache";
+        Directory.CreateDirectory(musicPath);
+
+        var musicLibrary = new MusicLibraryTestContext(musicPath);
+        musicLibrary.CreateTestMp3File("InitialSong.mp3", title: "Initial Song");
+
+        {
+            await using var initialContext = AppTestContext.Create();
+            initialContext.Configure<MusicServerSettings>(settings =>
+            {
+                settings.CachePath = cachePath;
+                settings.MusicFolderPath = musicPath;
+                settings.CacheRefreshInterval = TimeSpan.FromDays(1);
+            });
+
+            _ = await initialContext.ScanCatalog();
+        }
+
+        var musicCachePath = cachePath / "cache.json";
+        var cacheContent = await File.ReadAllTextAsync(musicCachePath, TestContext.Current.CancellationToken);
+        var cacheJson = JsonNode.Parse(cacheContent);
+        Assert.NotNull(cacheJson);
+        Assert.True(cacheJson.AsObject().Remove("LastScanDate"));
+        await File.WriteAllTextAsync(musicCachePath, cacheJson.ToJsonString(), TestContext.Current.CancellationToken);
+
+        musicLibrary.CreateTestMp3File("LaterSong.mp3", title: "Later Song");
+
+        await using var testContext = AppTestContext.Create();
+        testContext.Configure<MusicServerSettings>(settings =>
+        {
+            settings.CachePath = cachePath;
+            settings.MusicFolderPath = musicPath;
+            settings.CacheRefreshInterval = TimeSpan.FromDays(1);
+        });
+
+        var service = await testContext.ScanCatalog();
+
+        var song = Assert.Single(service.GetAllSongs());
+        Assert.Equal("Initial Song", song.Title);
+        Assert.Equal(1, service.ScanCount);
+        Assert.NotNull(service.LastScanDate);
+    }
+
+    [Fact]
+    public async Task StartAsync_RescansCachedLibrary_WhenCacheRefreshIntervalHasElapsed()
+    {
+        using var tempDir = TemporaryDirectory.Create();
+        var musicPath = tempDir / "music";
+        var cachePath = tempDir / "cache";
+        Directory.CreateDirectory(musicPath);
+
+        var musicLibrary = new MusicLibraryTestContext(musicPath);
+        musicLibrary.CreateTestMp3File("InitialSong.mp3", title: "Initial Song");
+
+        {
+            await using var initialContext = AppTestContext.Create();
+            initialContext.Configure<MusicServerSettings>(settings =>
+            {
+                settings.CachePath = cachePath;
+                settings.MusicFolderPath = musicPath;
+                settings.CacheRefreshInterval = TimeSpan.FromDays(1);
+            });
+
+            _ = await initialContext.ScanCatalog();
+        }
+
+        var musicCachePath = cachePath / "cache.json";
+        var cacheContent = await File.ReadAllTextAsync(musicCachePath, TestContext.Current.CancellationToken);
+        var cacheJson = JsonNode.Parse(cacheContent);
+        Assert.NotNull(cacheJson);
+        cacheJson["LastScanDate"] = DateTime.UtcNow.AddDays(-2);
+        await File.WriteAllTextAsync(musicCachePath, cacheJson.ToJsonString(), TestContext.Current.CancellationToken);
+
+        musicLibrary.CreateTestMp3File("LaterSong.mp3", title: "Later Song");
+
+        await using var testContext = AppTestContext.Create();
+        testContext.Configure<MusicServerSettings>(settings =>
+        {
+            settings.CachePath = cachePath;
+            settings.MusicFolderPath = musicPath;
+            settings.CacheRefreshInterval = TimeSpan.FromDays(1);
+        });
+
+        var service = await testContext.ScanCatalog();
+
+        var songs = service.GetAllSongs().ToList();
+        Assert.Equal(2, songs.Count);
+        Assert.Contains(songs, song => song.Title == "Initial Song");
+        Assert.Contains(songs, song => song.Title == "Later Song");
+    }
+
+    [Fact]
     public async Task ScanMusicLibrary_ExtractsLyricsFromMetadata()
     {
         await using var testContext = AppTestContext.Create();
@@ -630,6 +726,7 @@ public partial class MusicLibraryServiceTests
 
         cacheJson["Songs"]![0]!["Title"] = "Stale Cached Title";
         cacheJson["Songs"]![0]!["Duration"] = "00:00:00";
+        cacheJson["LastScanDate"] = DateTime.UtcNow.AddDays(-2);
         await File.WriteAllTextAsync(musicCachePath, cacheJson.ToJsonString(), TestContext.Current.CancellationToken);
 
         await using var testContext = AppTestContext.Create();

--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -215,7 +215,7 @@ public partial class MusicLibraryServiceTests
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
-    public async Task StartAsync_DisablesAutomaticRescan_WhenCacheRefreshIntervalIsZeroOrNegative(int intervalMilliseconds)
+    public async Task StartAsync_DisablesAutomaticScan_WhenCacheRefreshIntervalIsZeroOrNegative(int intervalMilliseconds)
     {
         await using var testContext = AppTestContext.Create();
         testContext.Configure<MusicServerSettings>(settings => settings.CacheRefreshInterval = TimeSpan.FromMilliseconds(intervalMilliseconds));
@@ -223,15 +223,52 @@ public partial class MusicLibraryServiceTests
 
         var service = await testContext.ScanCatalog();
 
-        var initialSong = Assert.Single(service.GetAllSongs());
-        Assert.Equal("Initial Song", initialSong.Title);
-        Assert.Equal(1, service.ScanCount);
+        Assert.Empty(service.GetAllSongs());
+        Assert.Equal(0, service.ScanCount);
 
         testContext.MusicLibrary.CreateTestMp3File("LaterSong.mp3", title: "Later Song");
         await Task.Delay(200, testContext.CancellationToken);
 
-        var songs = service.GetAllSongs().ToList();
-        var song = Assert.Single(songs);
+        Assert.Empty(service.GetAllSongs());
+        Assert.Equal(0, service.ScanCount);
+    }
+
+    [Fact]
+    public async Task StartAsync_UsesCachedLibraryWithoutScanning_WhenCacheRefreshIntervalIsZeroOrNegative()
+    {
+        using var tempDir = TemporaryDirectory.Create();
+        var musicPath = tempDir / "music";
+        var cachePath = tempDir / "cache";
+        Directory.CreateDirectory(musicPath);
+
+        var musicLibrary = new MusicLibraryTestContext(musicPath);
+        musicLibrary.CreateTestMp3File("InitialSong.mp3", title: "Initial Song");
+
+        {
+            await using var initialContext = AppTestContext.Create();
+            initialContext.Configure<MusicServerSettings>(settings =>
+            {
+                settings.CachePath = cachePath;
+                settings.MusicFolderPath = musicPath;
+                settings.CacheRefreshInterval = TimeSpan.FromDays(1);
+            });
+
+            _ = await initialContext.ScanCatalog();
+        }
+
+        musicLibrary.CreateTestMp3File("LaterSong.mp3", title: "Later Song");
+
+        await using var testContext = AppTestContext.Create();
+        testContext.Configure<MusicServerSettings>(settings =>
+        {
+            settings.CachePath = cachePath;
+            settings.MusicFolderPath = musicPath;
+            settings.CacheRefreshInterval = TimeSpan.Zero;
+        });
+
+        var service = await testContext.ScanCatalog();
+
+        var song = Assert.Single(service.GetAllSongs());
         Assert.Equal("Initial Song", song.Title);
         Assert.Equal(1, service.ScanCount);
     }

--- a/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
+++ b/Meziantou.MusicApp.Server/Models/MusicCatalog.cs
@@ -178,7 +178,7 @@ public sealed class MusicCatalog
         // Build directory structure
         result.BuildDirectoryStructure();
 
-        result.LastScanDate = DateTime.UtcNow;
+        result.LastScanDate = serializableCatalog.LastScanDate ?? DateTime.UtcNow;
 
         activity?.SetTag("music.catalog.final_songs", result.Songs.Count);
         activity?.SetTag("music.catalog.final_artists", result.Artists.Count);

--- a/Meziantou.MusicApp.Server/Models/SerializableMusicCatalog.cs
+++ b/Meziantou.MusicApp.Server/Models/SerializableMusicCatalog.cs
@@ -3,16 +3,16 @@ namespace Meziantou.MusicApp.Server.Models;
 internal sealed class SerializableMusicCatalog
 {
     /// <summary>
-    /// Current version of the cache format. Increment this when adding new properties
-    /// or changing the structure to force a rescan of the library.
+    /// Current version of the cache format. Increment this when making incompatible
+    /// changes or adding properties that require a rescan of the library.
     /// </summary>
     public const int CacheVersion = 5;
 
     public int Version { get; set; } = CacheVersion;
+    public DateTime? LastScanDate { get; set; }
     public List<SerializableSong> Songs { get; set; } = [];
     public List<SerializablePlaylist> Playlist { get; set; } = [];
     public List<SerializableMissingPlaylistItem> MissingPlaylistItems { get; set; } = [];
     public List<SerializableInvalidPlaylist> InvalidPlaylists { get; set; } = [];
     public List<SerializableUnnormalizedPlaylistItem> UnnormalizedPlaylistItems { get; set; } = [];
 }
-

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -102,6 +102,13 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
 
         await LoadCachedLibrary();
 
+        if (!options.Value.IsAutomaticLibraryRescanEnabled)
+        {
+            logger.LogInformation("Automatic music library rescan is disabled because {SettingName} is {CacheRefreshInterval}", nameof(MusicServerSettings.CacheRefreshInterval), options.Value.CacheRefreshInterval);
+            _initialScanCompleted.TrySetResult();
+            return;
+        }
+
         if (ShouldScanCachedLibrary())
         {
             logger.LogInformation("Starting initial music library scan");
@@ -111,12 +118,6 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         {
             logger.LogInformation("Using cached music library. Next scan is scheduled in {Delay}", GetDelayUntilNextScan());
             _initialScanCompleted.TrySetResult();
-        }
-
-        if (!options.Value.IsAutomaticLibraryRescanEnabled)
-        {
-            logger.LogInformation("Automatic music library rescan is disabled because {SettingName} is {CacheRefreshInterval}", nameof(MusicServerSettings.CacheRefreshInterval), options.Value.CacheRefreshInterval);
-            return;
         }
 
         while (!stoppingToken.IsCancellationRequested)
@@ -143,7 +144,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             return true;
 
         if (!options.Value.IsAutomaticLibraryRescanEnabled)
-            return true;
+            return false;
 
         return GetDelayUntilNextScan() <= TimeSpan.Zero;
     }

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -102,8 +102,16 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
 
         await LoadCachedLibrary();
 
-        logger.LogInformation("Starting initial music library scan");
-        await Task.Run(() => ScanMusicLibrary(), stoppingToken);
+        if (ShouldScanCachedLibrary())
+        {
+            logger.LogInformation("Starting initial music library scan");
+            await Task.Run(() => ScanMusicLibrary(), stoppingToken);
+        }
+        else
+        {
+            logger.LogInformation("Using cached music library. Next scan is scheduled in {Delay}", GetDelayUntilNextScan());
+            _initialScanCompleted.TrySetResult();
+        }
 
         if (!options.Value.IsAutomaticLibraryRescanEnabled)
         {
@@ -113,10 +121,45 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            await Task.Delay(options.Value.CacheRefreshInterval, stoppingToken);
+            var delay = GetDelayUntilNextScan();
+            if (delay <= TimeSpan.Zero)
+            {
+                delay = options.Value.CacheRefreshInterval;
+            }
+
+            if (delay > TimeSpan.Zero)
+            {
+                await Task.Delay(delay, stoppingToken);
+            }
+
             logger.LogInformation("Starting scheduled music library scan");
             await Task.Run(() => ScanMusicLibrary(), stoppingToken);
         }
+    }
+
+    private bool ShouldScanCachedLibrary()
+    {
+        if (_cachedSerializableCatalog is null)
+            return true;
+
+        if (!options.Value.IsAutomaticLibraryRescanEnabled)
+            return true;
+
+        return GetDelayUntilNextScan() <= TimeSpan.Zero;
+    }
+
+    private TimeSpan GetDelayUntilNextScan()
+    {
+        var lastScanDate = LastScanDate;
+        if (lastScanDate is null)
+            return TimeSpan.Zero;
+
+        var nextScanDate = lastScanDate.Value.ToUniversalTime() + options.Value.CacheRefreshInterval;
+        var delay = nextScanDate - DateTime.UtcNow;
+        if (delay <= TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        return delay;
     }
 
     private async Task LoadCachedLibrary()
@@ -143,8 +186,10 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                     return;
                 }
 
+                content.LastScanDate ??= File.GetLastWriteTimeUtc(cachePath);
                 _cachedSerializableCatalog = content;
                 _catalog = await CreateCatalog(content);
+                _scanCount = _catalog.Songs.Count;
                 logger.LogInformation("Loaded cached library");
             }
         }
@@ -274,6 +319,8 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
                 }
                 m3uActivity?.SetTag("music.library.m3u_playlists", m3uFiles.Length);
             }
+
+            library.LastScanDate = DateTime.UtcNow;
 
             var cachePath = GetCacheJsonPath();
             if (!cachePath.IsEmpty)

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
         "version": "10.0.301"
     },
     "msbuild-sdks": {
-        "Meziantou.NET.Sdk.Test": "1.0.115",
-        "Meziantou.NET.Sdk.Web": "1.0.115"
+        "Meziantou.NET.Sdk.Test": "1.0.116",
+        "Meziantou.NET.Sdk.Web": "1.0.116"
     }
 }


### PR DESCRIPTION
## Summary
- Preserve `LastScanDate` in the cached catalog and reuse it when rebuilding the in-memory catalog.
- Avoid the initial music library rescan on startup when the cache is still within `CacheRefreshInterval`.
- Keep automatic rescans scheduled from the cached scan time instead of always restarting the timer from startup.
- Add tests covering both cached-library startup paths and stale-cache reload behavior.

## Testing
- Added unit tests for fresh-cache startup, stale-cache startup, and cache timestamp handling.
- Not run (not requested).