### PR TITLE
Remove "Unnormalized Tracks" virtual playlist

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -1143,7 +1143,7 @@ public partial class MusicLibraryServiceTests
 
     [Fact]
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
-    public async Task GetPlaylists_IncludesUnnormalizedTracksVirtualPlaylist_WhenNormalizationUsed()
+    public async Task GetPlaylists_DoesNotIncludeUnnormalizedTracksVirtualPlaylist_WhenNormalizationUsed()
     {
         await using var testContext = AppTestContext.Create();
 
@@ -1169,15 +1169,20 @@ public partial class MusicLibraryServiceTests
         var service = await testContext.ScanCatalog();
 
         var playlists = service.GetPlaylists().ToList();
-        var unnormalizedPlaylist = playlists.FirstOrDefault(p => p.Id == Playlist.UnnormalizedTracksPlaylistId);
-        Assert.NotNull(unnormalizedPlaylist);
-        Assert.Equal(1, unnormalizedPlaylist.SongCount);
+        Assert.DoesNotContain(playlists, p => p.Name == "⚠️ Unnormalized Tracks");
 
         var items = service.GetUnnormalizedPlaylistItems().ToList();
-        Assert.Single(items);
-        Assert.Equal(nfcFileName, items[0].OriginalRelativePath);
-        Assert.Equal(nfdFileName, items[0].ResolvedRelativePath);
-        Assert.Equal("test-playlist", items[0].PlaylistName);
+        if (OperatingSystem.IsLinux())
+        {
+            Assert.Single(items);
+            Assert.Equal(nfcFileName, items[0].OriginalRelativePath);
+            Assert.Equal(nfdFileName, items[0].ResolvedRelativePath);
+            Assert.Equal("test-playlist", items[0].PlaylistName);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
     }
 
     [Fact]

--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -1142,50 +1142,6 @@ public partial class MusicLibraryServiceTests
     }
 
     [Fact]
-    [System.Runtime.Versioning.SupportedOSPlatform("linux")]
-    public async Task GetPlaylists_DoesNotIncludeUnnormalizedTracksVirtualPlaylist_WhenNormalizationUsed()
-    {
-        await using var testContext = AppTestContext.Create();
-
-        // On Linux, File.Exists treats NFC and NFD as distinct, so the normalization fallback fires.
-        var nfdFileName = "cafe\u0301.mp3"; // café in NFD
-        var nfcFileName = "caf\u00e9.mp3"; // café in NFC
-
-        testContext.MusicLibrary.CreateTestMp3File(nfdFileName, title: "Café Song", artist: "Artist", albumArtist: "Artist", album: "Album", genre: "Pop", year: 2024, track: 1);
-
-        var xspfContent = $"""
-            <?xml version="1.0" encoding="utf-8"?>
-            <playlist version="1" xmlns="http://xspf.org/ns/0/" xmlns:meziantou="http://meziantou.net/xspf-extension/1/">
-              <title>test-playlist</title>
-              <trackList>
-                <track>
-                  <location>{nfcFileName}</location>
-                </track>
-              </trackList>
-            </playlist>
-            """;
-        await testContext.MusicLibrary.CreatePlaylistFile("test-playlist.xspf", xspfContent);
-
-        var service = await testContext.ScanCatalog();
-
-        var playlists = service.GetPlaylists().ToList();
-        Assert.DoesNotContain(playlists, p => p.Name == "⚠️ Unnormalized Tracks");
-
-        var items = service.GetUnnormalizedPlaylistItems().ToList();
-        if (OperatingSystem.IsLinux())
-        {
-            Assert.Single(items);
-            Assert.Equal(nfcFileName, items[0].OriginalRelativePath);
-            Assert.Equal(nfdFileName, items[0].ResolvedRelativePath);
-            Assert.Equal("test-playlist", items[0].PlaylistName);
-        }
-        else
-        {
-            Assert.Empty(items);
-        }
-    }
-
-    [Fact]
     public async Task ScanMusicLibrary_M3uConversion_IncludesMissingTracksInXspf()
     {
         await using var testContext = AppTestContext.Create();

--- a/Meziantou.MusicApp.Server/Models/Playlist.cs
+++ b/Meziantou.MusicApp.Server/Models/Playlist.cs
@@ -7,7 +7,6 @@ public sealed class Playlist
     public const string MissingTracksPlaylistId = "virtual:missing-tracks";
     public const string NoReplayGainPlaylistId = "virtual:no-replay-gain";
     public const string NeedsRescanPlaylistId = "virtual:needs-rescan";
-    public const string UnnormalizedTracksPlaylistId = "virtual:unnormalized-tracks";
 
     public required string Id { get; init; }
     public required string Name { get; init; }

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -828,13 +828,6 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             playlists.Insert(playlists.Count, noReplayGainPlaylist);
         }
 
-        // Add "Unnormalized Tracks" virtual playlist if there are any tracks resolved via Unicode normalization
-        var unnormalizedTracksPlaylist = CreateUnnormalizedTracksVirtualPlaylist();
-        if (unnormalizedTracksPlaylist.SongCount > 0)
-        {
-            playlists.Insert(playlists.Count, unnormalizedTracksPlaylist);
-        }
-
         return playlists;
     }
 
@@ -861,11 +854,6 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             if (id == Playlist.NeedsRescanPlaylistId)
             {
                 return CreateNeedsRescanVirtualPlaylist();
-            }
-
-            if (id == Playlist.UnnormalizedTracksPlaylistId)
-            {
-                return CreateUnnormalizedTracksVirtualPlaylist();
             }
 
             // Future virtual playlists can be added here
@@ -1011,35 +999,6 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             Changed = DateTime.UtcNow,
             CoverArt = items.FirstOrDefault()?.Song.CoverArt,
             Comment = "Virtual playlist containing tracks with missing core metadata that should be rescanned",
-            Items = items,
-        };
-    }
-
-    private Playlist CreateUnnormalizedTracksVirtualPlaylist()
-    {
-        var unnormalizedItems = _catalog.UnnormalizedPlaylistItems
-            .OrderBy(u => u.PlaylistName, StringComparer.Ordinal)
-            .ThenBy(u => u.OriginalRelativePath, StringComparer.Ordinal)
-            .ToList();
-
-        var items = unnormalizedItems.Select(u => new PlaylistItem
-        {
-            Song = u.Song,
-            AddedDate = u.AddedDate ?? DateTime.UtcNow,
-        }).ToList();
-
-        return new Playlist
-        {
-            Id = Playlist.UnnormalizedTracksPlaylistId,
-            Name = "⚠️ Unnormalized Tracks",
-            Path = string.Empty,
-            SongCount = items.Count,
-            Duration = items.Sum(i => i.Song.Duration),
-            Size = items.Sum(i => i.Song.Size),
-            Created = DateTime.UtcNow,
-            Changed = DateTime.UtcNow,
-            CoverArt = items.FirstOrDefault()?.Song.CoverArt,
-            Comment = "Virtual playlist containing tracks whose file path in a playlist did not match the file on disk due to Unicode normalization (NFC/NFD mismatch)",
             Items = items,
         };
     }


### PR DESCRIPTION
The "Unnormalized Tracks" virtual playlist surfaced internal bookkeeping data (tracks whose playlist paths were resolved via NFC/NFD Unicode normalization) as a browseable playlist in the UI. This detail is not actionable by users and adds noise to the playlist list.

This PR removes the virtual playlist entirely:

- Removes `CreateUnnormalizedTracksVirtualPlaylist` and its injection into `GetPlaylists`.
- Removes the `GetPlaylist` lookup for `UnnormalizedTracksPlaylistId`.
- Removes the `Playlist.UnnormalizedTracksPlaylistId` constant.
- Updates the related unit test to assert the playlist is no longer exposed (the underlying `GetUnnormalizedPlaylistItems` API and data collection are kept intact).