### PR TITLE
Fix rescan race that delayed new tracks in WebPlayer

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Integration/RestApiIntegrationTests.cs
@@ -58,7 +58,12 @@ public class RestApiIntegrationTests
         await using var app = AppTestContext.Create();
         using var response = await app.Client.PostAsync("/api/scan.json", content: null, app.CancellationToken);
         InlineSnapshot
-            .WithSerializer(serializer => serializer.ScrubJsonValue("$.isScanning", node => "[redacted]"))
+            .WithSerializer(serializer =>
+            {
+                serializer.ScrubJsonValue("$.isScanning", node => "[redacted]");
+                serializer.ScrubJsonValue("$.activeScanGeneration", node => "[redacted]");
+                serializer.ScrubJsonValue("$.lastCompletedScanGeneration", node => "[redacted]");
+            })
             .Validate(response, """
                 StatusCode: 200 (OK)
                 Headers:
@@ -71,6 +76,8 @@ public class RestApiIntegrationTests
                       "isScanning": "[redacted]",
                       "isInitialScanCompleted": true,
                       "scanCount": 0,
+                      "activeScanGeneration": "[redacted]",
+                      "lastCompletedScanGeneration": "[redacted]",
                       "invalidPlaylists": []
                     }
                 """);
@@ -82,7 +89,12 @@ public class RestApiIntegrationTests
         await using var app = AppTestContext.Create();
         using var response = await app.Client.PostAsync("/api/scan.json?force=true", content: null, app.CancellationToken);
         InlineSnapshot
-            .WithSerializer(serializer => serializer.ScrubJsonValue("$.isScanning", node => "[redacted]"))
+            .WithSerializer(serializer =>
+            {
+                serializer.ScrubJsonValue("$.isScanning", node => "[redacted]");
+                serializer.ScrubJsonValue("$.activeScanGeneration", node => "[redacted]");
+                serializer.ScrubJsonValue("$.lastCompletedScanGeneration", node => "[redacted]");
+            })
             .Validate(response, """
                 StatusCode: 200 (OK)
                 Headers:
@@ -95,6 +107,8 @@ public class RestApiIntegrationTests
                       "isScanning": "[redacted]",
                       "isInitialScanCompleted": true,
                       "scanCount": 0,
+                      "activeScanGeneration": "[redacted]",
+                      "lastCompletedScanGeneration": "[redacted]",
                       "invalidPlaylists": []
                     }
                 """);
@@ -154,7 +168,12 @@ public class RestApiIntegrationTests
         await using var app = AppTestContext.Create();
         using var response = await app.Client.GetAsync("/api/scan/status.json", app.CancellationToken);
         InlineSnapshot
-            .WithSerializer(serializer => serializer.ScrubJsonValue("$.isScanning", node => "[redacted]"))
+            .WithSerializer(serializer =>
+            {
+                serializer.ScrubJsonValue("$.isScanning", node => "[redacted]");
+                serializer.ScrubJsonValue("$.activeScanGeneration", node => "[redacted]");
+                serializer.ScrubJsonValue("$.lastCompletedScanGeneration", node => "[redacted]");
+            })
             .Validate(response, """
                 StatusCode: 200 (OK)
                 Headers:
@@ -167,6 +186,8 @@ public class RestApiIntegrationTests
                       "isScanning": "[redacted]",
                       "isInitialScanCompleted": true,
                       "scanCount": 0,
+                      "activeScanGeneration": "[redacted]",
+                      "lastCompletedScanGeneration": "[redacted]",
                       "invalidPlaylists": []
                     }
                 """);

--- a/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
+++ b/Meziantou.MusicApp.Server.Tests/Unit/MusicLibraryServiceTests.cs
@@ -850,6 +850,23 @@ public partial class MusicLibraryServiceTests
     }
 
     [Fact]
+    public async Task ScanMusicLibrary_IncrementsCompletedGeneration()
+    {
+        await using var testContext = AppTestContext.Create();
+        testContext.MusicLibrary.CreateTestMp3File("Song1.mp3", title: "Song 1", artist: "Artist 1", albumArtist: "Artist 1", album: "Album 1", genre: "Rock", year: 2024, track: 1);
+
+        var service = await testContext.ScanCatalog();
+        var completedGeneration = service.LastCompletedScanGeneration;
+
+        testContext.MusicLibrary.CreateTestMp3File("Song2.mp3", title: "Song 2", artist: "Artist 2", albumArtist: "Artist 2", album: "Album 2", genre: "Pop", year: 2024, track: 1);
+
+        await service.ScanMusicLibrary();
+
+        Assert.Equal(0, service.ActiveScanGeneration);
+        Assert.True(service.LastCompletedScanGeneration > completedGeneration);
+    }
+
+    [Fact]
     public async Task ScanMusicLibrary_IncrementalScan_RemovesDeletedFiles()
     {
         await using var testContext = AppTestContext.Create();

--- a/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
+++ b/Meziantou.MusicApp.Server/Controllers/RestApiController.cs
@@ -372,6 +372,8 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
             TotalFiles = library.TotalFiles,
             ProcessedPlaylists = library.ProcessedPlaylists,
             TotalPlaylists = library.TotalPlaylists,
+            ActiveScanGeneration = library.ActiveScanGeneration,
+            LastCompletedScanGeneration = library.LastCompletedScanGeneration,
         });
     }
 
@@ -392,6 +394,8 @@ public class RestApiController(MusicLibraryService library, TranscodingService t
             TotalFiles = library.TotalFiles,
             ProcessedPlaylists = library.ProcessedPlaylists,
             TotalPlaylists = library.TotalPlaylists,
+            ActiveScanGeneration = library.ActiveScanGeneration,
+            LastCompletedScanGeneration = library.LastCompletedScanGeneration,
             InvalidPlaylists = library.Catalog.InvalidPlaylists.Select(p => new InvalidPlaylistInfo
             {
                 Path = p.Path,

--- a/Meziantou.MusicApp.Server/Models/RestApi/ScanStatusResponse.cs
+++ b/Meziantou.MusicApp.Server/Models/RestApi/ScanStatusResponse.cs
@@ -12,5 +12,7 @@ public class ScanStatusResponse
     public int? TotalFiles { get; set; }
     public int? ProcessedPlaylists { get; set; }
     public int? TotalPlaylists { get; set; }
+    public long ActiveScanGeneration { get; set; }
+    public long LastCompletedScanGeneration { get; set; }
     public List<InvalidPlaylistInfo> InvalidPlaylists { get; set; } = [];
 }

--- a/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
+++ b/Meziantou.MusicApp.Server/Services/MusicLibraryService.cs
@@ -29,6 +29,9 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     private int _totalPlaylistsToScan;
     private DateTime _scanStartTime;
     private CancellationToken _cancellationToken = CancellationToken.None;
+    private long _scanGenerationCounter;
+    private long _activeScanGeneration;
+    private long _lastCompletedScanGeneration;
 
     private static readonly XNamespace XspfNamespace = "http://xspf.org/ns/0/";
     private static readonly XNamespace MeziantouExtensionNamespace = "http://meziantou.net/xspf-extension/1/";
@@ -62,6 +65,8 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
     public int? TotalFiles => IsScanning ? _totalFilesToScan : null;
     public int? ProcessedPlaylists => IsScanning ? _processedPlaylistsCount : null;
     public int? TotalPlaylists => IsScanning ? _totalPlaylistsToScan : null;
+    public long ActiveScanGeneration => IsScanning ? Volatile.Read(ref _activeScanGeneration) : 0;
+    public long LastCompletedScanGeneration => Volatile.Read(ref _lastCompletedScanGeneration);
     public double? ScanProgress
     {
         get
@@ -247,6 +252,8 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
             }
 
             lockAcquired = true;
+            var activeScanGeneration = Interlocked.Increment(ref _scanGenerationCounter);
+            Volatile.Write(ref _activeScanGeneration, activeScanGeneration);
             logger.LogInformation("Scanning music library");
             var library = new SerializableMusicCatalog();
             var files = Directory.EnumerateFiles(rootFolder, "*", new EnumerationOptions { AttributesToSkip = FileAttributes.None, IgnoreInaccessible = true, RecurseSubdirectories = true })
@@ -386,6 +393,7 @@ public sealed class MusicLibraryService(ILogger<MusicLibraryService> logger, IOp
         {
             if (lockAcquired)
             {
+                Volatile.Write(ref _lastCompletedScanGeneration, Volatile.Read(ref _activeScanGeneration));
                 _scanSemaphore.Release();
             }
 

--- a/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
+++ b/Meziantou.MusicApp.WebPlayer/src/hooks/useApp.tsx
@@ -883,6 +883,16 @@ function AppDataProvider({ children }: AppProviderProps) {
 
     try {
       const api = getApiService();
+      let baselineLastCompletedGeneration: number | null = null;
+      let baselineLastScanDate: Date | null = null;
+      try {
+        const baselineStatus = await api.getScanStatus();
+        baselineLastCompletedGeneration = baselineStatus.lastCompletedScanGeneration ?? null;
+        baselineLastScanDate = baselineStatus.lastScanDate ? new Date(baselineStatus.lastScanDate) : null;
+      } catch (error) {
+        console.warn('Failed to get baseline scan status before triggering scan:', error);
+      }
+
       await api.triggerScan(force);
       showToast(force ? 'Force library scan started' : 'Library scan started', 'success');
 
@@ -891,6 +901,8 @@ function AppDataProvider({ children }: AppProviderProps) {
         void (async () => {
           const maxAttempts = 120;
           const pollIntervalMs = 2000;
+          let observedActiveScan = false;
+
           for (let attempt = 0; attempt < maxAttempts; attempt++) {
             if (scanRefreshRequestIdRef.current !== requestId) {
               return;
@@ -902,7 +914,22 @@ function AppDataProvider({ children }: AppProviderProps) {
                 setInvalidPlaylists(status.invalidPlaylists);
               }
 
-              if (!status.isScanning) {
+              if (status.isScanning) {
+                observedActiveScan = true;
+              }
+
+              const currentLastScanDate = status.lastScanDate ? new Date(status.lastScanDate) : null;
+              const hasCompletedGenerationAdvanced = baselineLastCompletedGeneration !== null &&
+                typeof status.lastCompletedScanGeneration === 'number' &&
+                status.lastCompletedScanGeneration > baselineLastCompletedGeneration;
+              const hasLastScanDateAdvanced = baselineLastScanDate !== null &&
+                !Number.isNaN(baselineLastScanDate.getTime()) &&
+                currentLastScanDate !== null &&
+                !Number.isNaN(currentLastScanDate.getTime()) &&
+                currentLastScanDate > baselineLastScanDate;
+              const hasObservedStartAndStop = observedActiveScan && !status.isScanning;
+
+              if (hasCompletedGenerationAdvanced || hasLastScanDateAdvanced || hasObservedStartAndStop) {
                 await syncPlaylistsInternal({ refreshAllTracks: true });
                 return;
               }
@@ -913,6 +940,8 @@ function AppDataProvider({ children }: AppProviderProps) {
 
             await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
           }
+
+          await syncPlaylistsInternal({ refreshAllTracks: true });
         })();
       }, 1000);
     } catch (error) {

--- a/Meziantou.MusicApp.WebPlayer/src/types/api.ts
+++ b/Meziantou.MusicApp.WebPlayer/src/types/api.ts
@@ -103,6 +103,8 @@ export interface ScanStatusResponse {
   totalFiles: number | null;
   processedPlaylists: number | null;
   totalPlaylists: number | null;
+  activeScanGeneration?: number | null;
+  lastCompletedScanGeneration?: number | null;
   invalidPlaylists: InvalidPlaylistInfo[];
 }
 


### PR DESCRIPTION
## Why
When users triggered **Rescan Music Library**, the WebPlayer could stop monitoring too early if it observed `isScanning = false` before the background scan actually started. In that case, playlist/track refresh happened too soon, so newly added songs were not shown until a later refresh path.

## What changed
- Added scan-generation metadata to server scan responses:
  - `activeScanGeneration`
  - `lastCompletedScanGeneration`
- Returned those fields from both:
  - `POST /api/scan.json`
  - `GET /api/scan/status.json`
- Updated WebPlayer scan monitoring (`useApp.tsx`) to:
  - capture a baseline scan status before triggering a scan
  - keep polling until completion is confirmed by one of:
    - completed generation advanced
    - last scan date advanced
    - observed `isScanning` transition from true back to false
  - refresh playlists/tracks only after completion is confirmed
  - perform a final refresh fallback when polling limit is reached
- Updated API typings and tests to cover the new metadata and behavior.

## Notes
This is backward-compatible for existing clients, and it hardens scan completion detection without changing the scan trigger endpoint contract.