### PR TITLE
Update Meziantou.NET.Sdk to 1.0.148

### DIFF
--- a/Meziantou.MusicApp.Server.Tests/Meziantou.MusicApp.Server.Tests.csproj
+++ b/Meziantou.MusicApp.Server.Tests/Meziantou.MusicApp.Server.Tests.csproj
@@ -6,11 +6,6 @@
     <PackageReference Include="Meziantou.Framework.InlineSnapshotTesting" Version="6.0.2" />
     <PackageReference Include="Meziantou.Framework.TemporaryDirectory" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -2,8 +2,11 @@
     "sdk": {
         "version": "10.0.302"
     },
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    },
     "msbuild-sdks": {
-        "Meziantou.NET.Sdk.Test": "1.0.139",
-        "Meziantou.NET.Sdk.Web": "1.0.139"
+        "Meziantou.NET.Sdk.Test": "1.0.148",
+        "Meziantou.NET.Sdk.Web": "1.0.148"
     }
 }


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` to 1.0.148 in `global.json`.

- Opt in to Microsoft Testing Platform via the `test.runner` setting in `global.json`
- Remove the `xunit.v3` / `xunit.runner.visualstudio` package references, now added by `Meziantou.NET.Sdk.Test`
